### PR TITLE
perf(render): separate content and status-bar render regions

### DIFF
--- a/crates/client/src/window/mod.rs
+++ b/crates/client/src/window/mod.rs
@@ -182,6 +182,10 @@ mod win32 {
         pub news_scroll_px_per_tick: i32,
         /// PaneStore.news_text のキャッシュ（Win32 スレッド専用 — 毎フレームの lock を省く）
         news_text_cache: std::cell::RefCell<String>,
+        /// CPU/RAM ポーリング間引きカウンタ（60 フレームごとに更新 ≈ 1 秒）
+        sysinfo_tick: std::cell::Cell<u32>,
+        /// ステータスバー領域が更新されたことを示すフラグ（WM_TIMER → paint で使用）
+        status_bar_dirty: std::cell::Cell<bool>,
         /// CPU 使用率（0–100、GetSystemTimes デルタから算出）
         cpu_usage: std::cell::Cell<f32>,
         /// メモリ使用率（0–100、GlobalMemoryStatusEx から算出）
@@ -241,6 +245,8 @@ mod win32 {
                 news_scroll_px: std::cell::Cell::new(0),
                 news_scroll_px_per_tick,
                 news_text_cache: std::cell::RefCell::new(String::new()),
+                sysinfo_tick: std::cell::Cell::new(0),
+                status_bar_dirty: std::cell::Cell::new(false),
                 cpu_usage: std::cell::Cell::new(0.0),
                 mem_usage: std::cell::Cell::new(0.0),
                 prev_idle_ticks: std::cell::Cell::new(0),
@@ -1099,8 +1105,16 @@ mod win32 {
             }
         }
 
-        // ── ステータスバー ───────────────────────────────────────────
-        paint_status_bar(mem_dc, rect.right, rect.bottom, state);
+        // ── ステータスバー（更新が必要なフレームのみ描画）────────────────
+        // ps.rcPaint がステータスバー領域を含む場合のみ描画する。
+        // WM_TIMER 側でペイン dirty とステータスバー dirty を別 RECT で
+        // InvalidateRect しているため、ペイン出力だけの場合は rcPaint.bottom が
+        // bar_y 以下に収まりステータスバー描画がスキップされる。
+        let bar_h_px = state.cell_height * STATUS_BAR_ROWS;
+        let bar_y_px = win_h - bar_h_px;
+        if ps.rcPaint.bottom > bar_y_px {
+            paint_status_bar(mem_dc, rect.right, rect.bottom, state);
+        }
 
         // ── トースト通知 ────────────────────────────────────────────
         paint_toasts(mem_dc, rect.right, rect.bottom, state);

--- a/crates/client/src/window/win32/wndproc.rs
+++ b/crates/client/src/window/win32/wndproc.rs
@@ -312,8 +312,12 @@ pub(super) unsafe fn handle_wm_timer(
             }
         }
 
-        // CPU 使用率（GetSystemTimes デルタ）
-        {
+        // ── sysinfo（CPU/RAM）は 60 フレームごと（≈1秒）に更新 ───────────────
+        let tick = state.sysinfo_tick.get().wrapping_add(1);
+        state.sysinfo_tick.set(tick);
+        let sysinfo_updated = tick % 60 == 0;
+        if sysinfo_updated {
+            // CPU 使用率（GetSystemTimes デルタ）
             let mut idle = windows::Win32::Foundation::FILETIME::default();
             let mut kernel = windows::Win32::Foundation::FILETIME::default();
             let mut user = windows::Win32::Foundation::FILETIME::default();
@@ -341,10 +345,7 @@ pub(super) unsafe fn handle_wm_timer(
                 state.prev_kernel_ticks.set(kernel_now);
                 state.prev_user_ticks.set(user_now);
             }
-        }
-
-        // メモリ使用率（GlobalMemoryStatusEx）
-        {
+            // メモリ使用率（GlobalMemoryStatusEx）
             let mut ms = MEMORYSTATUSEX {
                 dwLength: std::mem::size_of::<MEMORYSTATUSEX>() as u32,
                 ..Default::default()
@@ -354,18 +355,35 @@ pub(super) unsafe fn handle_wm_timer(
             }
         }
 
-        // PaneStore.news_text を Win32 スレッドのキャッシュに同期してスクロール位置を進める。
-        // paint_status_bar はキャッシュから読むため PaneStore の追加 lock が不要になる。
+        // ── news_text 同期・ティッカースクロール ──────────────────────────────
+        // PaneStore から1フレーム1回だけ読んでキャッシュに保存。
         {
             let new_text = state.panes.lock().unwrap().news_text.clone();
             *state.news_text_cache.borrow_mut() = new_text;
         }
-        if state.news_scroll_px_per_tick > 0 && !state.news_text_cache.borrow().is_empty() {
+        let ticker_active =
+            state.news_scroll_px_per_tick > 0 && !state.news_text_cache.borrow().is_empty();
+        if ticker_active {
             let cur = state.news_scroll_px.get();
             state.news_scroll_px.set(cur + state.news_scroll_px_per_tick);
         }
 
-        let needs_repaint = {
+        // ── ステータスバーの dirty 判定 ──────────────────────────────────────
+        // ティッカーが動いている、または sysinfo が更新されたフレームのみ dirty にする。
+        let status_dirty = ticker_active || sysinfo_updated;
+        state.status_bar_dirty.set(status_dirty);
+
+        // ── 描画領域を分離して InvalidateRect ────────────────────────────────
+        // ペインコンテンツとステータスバーを別々に無効化することで、
+        // エージェント出力が多い場面でもステータスバーの余分な再描画を抑える。
+        let mut client_rect = RECT::default();
+        GetClientRect(hwnd, &mut client_rect).ok();
+        let win_h = client_rect.bottom;
+        let win_w = client_rect.right;
+        let bar_h = state.cell_height * STATUS_BAR_ROWS;
+        let bar_y = win_h - bar_h;
+
+        let needs_content_repaint = {
             let store = state.panes.lock().unwrap();
             let dirty = store
                 .grids
@@ -373,8 +391,14 @@ pub(super) unsafe fn handle_wm_timer(
                 .any(|g| g.lock().unwrap().has_dirty_rows());
             dirty || state.ime.state.lock().unwrap().composing
         };
-        if needs_repaint || has_active_toasts {
-            let _ = InvalidateRect(Some(hwnd), None, false);
+
+        if needs_content_repaint || has_active_toasts {
+            let content_rect = RECT { left: 0, top: 0, right: win_w, bottom: bar_y.max(0) };
+            let _ = InvalidateRect(Some(hwnd), Some(&content_rect), false);
+        }
+        if status_dirty || has_active_toasts {
+            let sb_rect = RECT { left: 0, top: bar_y.max(0), right: win_w, bottom: win_h };
+            let _ = InvalidateRect(Some(hwnd), Some(&sb_rect), false);
         }
     }
     LRESULT(0)


### PR DESCRIPTION
## 問題

エージェント稼働中にニュースティッカーを含むステータスバーの描画が重くなる。

## 原因

`InvalidateRect(None)`（全体無効化）を毎フレーム呼んでいたため、ペインに dirty な行がある（= エージェントが出力している）とステータスバーも毎フレーム `paint_status_bar()` が実行されていた。

## 変更内容

### 描画領域の分離

`handle_wm_timer` の `InvalidateRect` をコンテンツ領域とステータスバー領域に分離:

- ペイン dirty → `RECT { top: 0, bottom: bar_y }` のみ無効化
- ティッカー動作中 / sysinfo 更新時 → `RECT { top: bar_y, bottom: win_h }` のみ無効化

`paint()` では `ps.rcPaint.bottom > bar_y` のときだけ `paint_status_bar()` を呼ぶ。

### CPU/RAM ポーリングの間引き

`GetSystemTimes` / `GlobalMemoryStatusEx` を毎 16ms フレームから 60 フレームごと（≈1秒）に変更。Win32 API の呼び出し回数を 60 分の 1 に削減。

## 効果

エージェント実行中: ペイン出力フレームではステータスバー描画がスキップされる。ステータスバーはティッカーが動いているときだけ、sysinfo は約 1 秒に 1 回だけ再描画される。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)