### PR TITLE
feat(notify): pane border alert on notification (C-41)

### DIFF
--- a/crates/client/src/layout.rs
+++ b/crates/client/src/layout.rs
@@ -15,7 +15,7 @@ pub use catalog::{
     list_available_layouts, list_available_themes, load_theme_from_file, save_layout_file,
 };
 pub use launcher::{LauncherState, LayoutPreview, ThemeLauncherState};
-pub use store::{CopyState, PaneStore, PromptState, Toast};
+pub use store::{CopyState, PaneStore, PromptState, Toast, ALERT_FLIP_COUNT, ALERT_TICK_DIVISOR};
 pub use tree::{Direction, LayoutNode, PaneRect};
 
 /// 現在のレイアウトツリーを `[[panes]]` TOML 形式に変換する。

--- a/crates/client/src/layout/catalog.rs
+++ b/crates/client/src/layout/catalog.rs
@@ -129,6 +129,7 @@ pub fn load_theme_from_file(name: &str) -> Option<Theme> {
         status_bar_bg: parse(&ap.status_bar_bg),
         font_family: None,
         font_size: None,
+        alert_border: None,
     })
 }
 

--- a/crates/client/src/layout/store.rs
+++ b/crates/client/src/layout/store.rs
@@ -456,7 +456,7 @@ impl PaneStore {
             return false;
         }
         self.alert_tick = self.alert_tick.wrapping_add(1);
-        if self.alert_tick % ALERT_TICK_DIVISOR == 0 {
+        if self.alert_tick.is_multiple_of(ALERT_TICK_DIVISOR) {
             self.alerting_panes.retain(|_, count| {
                 *count = count.saturating_sub(1);
                 *count > 0

--- a/crates/client/src/layout/store.rs
+++ b/crates/client/src/layout/store.rs
@@ -6,6 +6,12 @@ use yatamux_terminal::Grid;
 
 use super::{LauncherState, LayoutNode, PaneRect, ThemeLauncherState};
 
+/// 点滅 1 回あたりの WM_TIMER ティック数（16ms × 16 ≈ 256ms per flip）
+pub const ALERT_TICK_DIVISOR: u8 = 16;
+/// 初期フリップ回数（ON/OFF ペア × 5 = 10 → 約 2.5 秒）
+/// 偶数からスタートし even=ON, odd=OFF なので最初は ON で始まる。
+pub const ALERT_FLIP_COUNT: u8 = 10;
+
 /// アプリ内入力欄の編集状態。
 ///
 /// 現在はレイアウト保存プロンプトで使用するが、履歴・カーソル移動・
@@ -337,6 +343,14 @@ pub struct PaneStore {
     /// `WM_TIMER` で検出し `content_bb` を破棄して全画面再描画をトリガーする。
     /// 残像（旧ペイン領域の描画残り）を防ぐために使用する。
     pub layout_changed: bool,
+    /// 通知アラート中のペイン → 残りフリップ数（0 = 非アラート）
+    ///
+    /// 偶数カウント = ボーダー ON、奇数カウント = ボーダー OFF。
+    /// `WM_TIMER` 毎に `tick_alert()` を呼び、`ALERT_TICK_DIVISOR` ティックごとに
+    /// カウントをデクリメントする。0 になったエントリは除去される。
+    pub alerting_panes: HashMap<PaneId, u8>,
+    /// 点滅タイマー用サブカウンタ（`ALERT_TICK_DIVISOR` で wrap して使用）
+    pub alert_tick: u8,
     /// マウスホバー中の URL 情報: (pane_id, row, col_start, col_end_exclusive, url)
     ///
     /// `WM_MOUSEMOVE` で更新。描画ループでアンダーラインを引くために参照する。
@@ -374,6 +388,8 @@ impl PaneStore {
             pane_aliases: HashMap::new(),
             pane_roles: HashMap::new(),
             layout_changed: false,
+            alerting_panes: HashMap::new(),
+            alert_tick: 0,
             hovered_url: None,
             news_text: String::new(),
         }
@@ -410,6 +426,45 @@ impl PaneStore {
         }
     }
 
+    /// 指定ペインの通知アラートを開始する（再トリガーするとフリップ数をリセット）。
+    pub fn trigger_alert(&mut self, pane_id: PaneId) {
+        self.alerting_panes.insert(pane_id, ALERT_FLIP_COUNT);
+    }
+
+    /// 指定ペインのアラートを即座に解除する（アクティブ化時などに使用）。
+    pub fn clear_alert(&mut self, pane_id: PaneId) {
+        self.alerting_panes.remove(&pane_id);
+    }
+
+    /// 指定ペインがアラートの点灯フェーズ（ボーダー表示）かどうかを返す。
+    ///
+    /// 偶数カウント = ON（最初のフリップは 10 = 偶数 → 即座に ON）。
+    pub fn is_alert_on(&self, pane_id: PaneId) -> bool {
+        match self.alerting_panes.get(&pane_id) {
+            Some(&count) if count > 0 => count % 2 == 0,
+            _ => false,
+        }
+    }
+
+    /// `WM_TIMER` 16ms ティックごとに呼ぶ。
+    ///
+    /// `ALERT_TICK_DIVISOR` ティックに 1 回フリップカウントをデクリメントし、
+    /// 0 になったペインを除去する。アラート中のペインが残っている間は `true` を返す。
+    pub fn tick_alert(&mut self) -> bool {
+        if self.alerting_panes.is_empty() {
+            self.alert_tick = 0;
+            return false;
+        }
+        self.alert_tick = self.alert_tick.wrapping_add(1);
+        if self.alert_tick % ALERT_TICK_DIVISOR == 0 {
+            self.alerting_panes.retain(|_, count| {
+                *count = count.saturating_sub(1);
+                *count > 0
+            });
+        }
+        !self.alerting_panes.is_empty()
+    }
+
     pub fn push_save_prompt_history(&mut self, entry: String) {
         const HISTORY_LIMIT: usize = 20;
 
@@ -438,7 +493,7 @@ mod tests {
     use yatamux_protocol::types::PaneId;
     use yatamux_terminal::Grid;
 
-    use super::{CopyState, PaneStore, PromptState};
+    use super::{CopyState, PaneStore, PromptState, ALERT_FLIP_COUNT, ALERT_TICK_DIVISOR};
     use crate::layout::PaneRect;
 
     // TC-01: layout_changed は false で初期化される
@@ -637,5 +692,149 @@ mod tests {
         assert!(cs.is_selected(0, 4));
         assert!(cs.is_selected(8, 4));
         assert!(!cs.is_selected(9, 4));
+    }
+
+    fn make_store() -> PaneStore {
+        let grid = Arc::new(Mutex::new(Grid::new(80, 24, Default::default())));
+        PaneStore::new(PaneId(1), grid)
+    }
+
+    // TC-C41-11: 初期状態で alerting_panes は空
+    #[test]
+    fn test_alert_initial_empty() {
+        let store = make_store();
+        assert!(store.alerting_panes.is_empty());
+        assert!(!store.is_alert_on(PaneId(1)));
+    }
+
+    // TC-C41-10: trigger_alert でペインが追加される
+    #[test]
+    fn test_trigger_alert_inserts_pane() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(2));
+        assert!(store.alerting_panes.contains_key(&PaneId(2)));
+        assert_eq!(store.alerting_panes[&PaneId(2)], ALERT_FLIP_COUNT);
+    }
+
+    // TC-C41-12: トリガー直後は is_alert_on が true
+    #[test]
+    fn test_is_alert_on_after_trigger() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        // ALERT_FLIP_COUNT=10 は偶数 → ON
+        assert!(store.is_alert_on(PaneId(1)));
+    }
+
+    // TC-C41-13: 登録されていないペインは false
+    #[test]
+    fn test_is_alert_on_unregistered_false() {
+        let store = make_store();
+        assert!(!store.is_alert_on(PaneId(99)));
+    }
+
+    // TC-C41-14: ALERT_TICK_DIVISOR 回 tick するとフリップ数が 1 減る
+    #[test]
+    fn test_tick_alert_decrements_flip_count() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        for _ in 0..ALERT_TICK_DIVISOR {
+            store.tick_alert();
+        }
+        assert_eq!(store.alerting_panes[&PaneId(1)], ALERT_FLIP_COUNT - 1);
+    }
+
+    // TC-C41-15: tick_alert はアラート中 true を返す
+    #[test]
+    fn test_tick_alert_returns_true_while_alerting() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        assert!(store.tick_alert());
+    }
+
+    // TC-C41-16: 全フリップ後に alerting_panes から除去される
+    #[test]
+    fn test_tick_alert_removes_pane_after_all_flips() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        let total_ticks = ALERT_TICK_DIVISOR as u32 * ALERT_FLIP_COUNT as u32;
+        for _ in 0..total_ticks {
+            store.tick_alert();
+        }
+        assert!(store.alerting_panes.is_empty());
+        assert!(!store.is_alert_on(PaneId(1)));
+    }
+
+    // TC-C41-17: 全フリップ完了後 tick_alert は false を返す
+    #[test]
+    fn test_tick_alert_returns_false_after_completion() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        let total_ticks = ALERT_TICK_DIVISOR as u32 * ALERT_FLIP_COUNT as u32;
+        for _ in 0..total_ticks {
+            store.tick_alert();
+        }
+        assert!(!store.tick_alert());
+    }
+
+    // TC-C41-18: ON/OFF フェーズが交互に切り替わる
+    #[test]
+    fn test_alert_phase_alternates() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        // 初期: count=10(偶数) → ON
+        assert!(store.is_alert_on(PaneId(1)));
+        // 1 フリップ後: count=9(奇数) → OFF
+        for _ in 0..ALERT_TICK_DIVISOR {
+            store.tick_alert();
+        }
+        assert!(!store.is_alert_on(PaneId(1)));
+        // 2 フリップ後: count=8(偶数) → ON
+        for _ in 0..ALERT_TICK_DIVISOR {
+            store.tick_alert();
+        }
+        assert!(store.is_alert_on(PaneId(1)));
+    }
+
+    // TC-C41-19: clear_alert でアラートが即座に解除される
+    #[test]
+    fn test_clear_alert_removes_pane() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        store.clear_alert(PaneId(1));
+        assert!(store.alerting_panes.is_empty());
+        assert!(!store.is_alert_on(PaneId(1)));
+    }
+
+    // TC-C41-20: 複数ペインを同時にアラートできる
+    #[test]
+    fn test_multiple_panes_alerting() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        store.trigger_alert(PaneId(2));
+        assert!(store.is_alert_on(PaneId(1)));
+        assert!(store.is_alert_on(PaneId(2)));
+    }
+
+    // TC-C41-21: clear_alert は存在しないペインにパニックしない
+    #[test]
+    fn test_clear_alert_nonexistent_no_panic() {
+        let mut store = make_store();
+        store.clear_alert(PaneId(99)); // パニックしないこと
+    }
+
+    // TC-C41-22: trigger_alert 再トリガーでフリップ数がリセットされる
+    #[test]
+    fn test_retrigger_resets_flip_count() {
+        let mut store = make_store();
+        store.trigger_alert(PaneId(1));
+        // 数フリップ進める
+        for _ in 0..(ALERT_TICK_DIVISOR as u32 * 3) {
+            store.tick_alert();
+        }
+        let count_mid = store.alerting_panes[&PaneId(1)];
+        assert!(count_mid < ALERT_FLIP_COUNT);
+        // 再トリガー
+        store.trigger_alert(PaneId(1));
+        assert_eq!(store.alerting_panes[&PaneId(1)], ALERT_FLIP_COUNT);
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -63,7 +63,7 @@ pub use layout::{
     CopyState, Direction, LauncherState, LayoutNode, LayoutPreview, PaneRect, PaneStore,
     PromptState, ThemeLauncherState, Toast,
 };
-pub use notification::{FocusAwareBackend, NotificationBackend};
+pub use notification::{AlertingBackend, FocusAwareBackend, NotificationBackend};
 pub use session::{LayoutNodeDef, LayoutSnapshot};
 pub use theme::Theme;
 pub use window::run_window;

--- a/crates/client/src/notification.rs
+++ b/crates/client/src/notification.rs
@@ -77,6 +77,32 @@ impl NotificationBackend for NativeToast {
     }
 }
 
+// ── AlertingBackend ────────────────────────────────────────────────────────
+
+/// 通知受信時にペインボーダーアラートを起動するラッパー。
+///
+/// 内部バックエンド（`FocusAwareBackend` 等）に処理を委譲しつつ、
+/// `PaneStore::trigger_alert` を必ず呼んでボーダー点滅を開始する。
+pub struct AlertingBackend<I: NotificationBackend> {
+    store: Arc<Mutex<PaneStore>>,
+    inner: I,
+}
+
+impl<I: NotificationBackend> AlertingBackend<I> {
+    pub fn new(store: Arc<Mutex<PaneStore>>, inner: I) -> Self {
+        Self { store, inner }
+    }
+}
+
+impl<I: NotificationBackend> NotificationBackend for AlertingBackend<I> {
+    fn notify(&self, pane_id: PaneId, message: String) {
+        // ボーダーアラートを開始（フォーカス状態に関わらず常に）
+        self.store.lock().unwrap().trigger_alert(pane_id);
+        // 内部バックエンド（トースト / OS 通知）に委譲
+        self.inner.notify(pane_id, message);
+    }
+}
+
 // ── FocusAwareBackend ──────────────────────────────────────────────────────
 
 /// フォーカス状態に応じて InternalToast / NativeToast を切り替えるラッパー
@@ -126,6 +152,43 @@ mod tests {
     fn make_store() -> Arc<Mutex<PaneStore>> {
         let grid = Arc::new(Mutex::new(Grid::new(80, 24, Default::default())));
         Arc::new(Mutex::new(PaneStore::new(PaneId(1), grid)))
+    }
+
+    // TC-C41-30: AlertingBackend::notify で trigger_alert が呼ばれる
+    #[test]
+    fn test_alerting_backend_triggers_alert() {
+        let store = make_store();
+        let internal = InternalToast::new(Arc::clone(&store));
+        let backend = AlertingBackend::new(Arc::clone(&store), internal);
+        backend.notify(PaneId(2), "test".to_string());
+        let store = store.lock().unwrap();
+        assert!(store.alerting_panes.contains_key(&PaneId(2)));
+    }
+
+    // TC-C41-31: AlertingBackend::notify は内部バックエンドにも委譲する
+    #[test]
+    fn test_alerting_backend_delegates_to_inner() {
+        let store = make_store();
+        let internal = InternalToast::new(Arc::clone(&store));
+        let backend = AlertingBackend::new(Arc::clone(&store), internal);
+        backend.notify(PaneId(2), "hello".to_string());
+        let store = store.lock().unwrap();
+        // InternalToast が pending_toasts に追加しているはず
+        assert_eq!(store.pending_toasts.len(), 1);
+        assert_eq!(store.pending_toasts[0].message, "hello");
+    }
+
+    // TC-C41-32: AlertingBackend はアクティブペインへの通知でも trigger_alert を呼ぶ
+    #[test]
+    fn test_alerting_backend_triggers_alert_for_active_pane() {
+        let store = make_store();
+        // store.active = PaneId(1)（デフォルト）
+        let internal = InternalToast::new(Arc::clone(&store));
+        let backend = AlertingBackend::new(Arc::clone(&store), internal);
+        backend.notify(PaneId(1), "active pane msg".to_string());
+        let store = store.lock().unwrap();
+        // AlertingBackend はアクティブチェックを行わず常に trigger_alert を呼ぶ
+        assert!(store.alerting_panes.contains_key(&PaneId(1)));
     }
 
     // TC-07: InternalToast — notify が pending_toasts に追加される

--- a/crates/client/src/theme.rs
+++ b/crates/client/src/theme.rs
@@ -18,4 +18,6 @@ pub struct Theme {
     pub font_family: Option<String>,
     /// フォントサイズ（pt）
     pub font_size: Option<u32>,
+    /// 通知アラート時のペインボーダー色（`0xRRGGBB`、`None` = デフォルト `#FF6B6B`）
+    pub alert_border: Option<u32>,
 }

--- a/crates/client/src/window/mod.rs
+++ b/crates/client/src/window/mod.rs
@@ -649,6 +649,7 @@ mod win32 {
             has_save_prompt,
             floating_visible,
             hovered_url,
+            alert_on_panes,
         ) = {
             let store = state.panes.lock().unwrap();
             let rects = store.layout.compute_rects(total_rect);
@@ -665,6 +666,13 @@ mod win32 {
             let hsp = store.save_prompt.is_some();
             let fv = store.floating_visible;
             let hu = store.hovered_url.clone();
+            // アラート ON フェーズのペイン ID セットを収集（ロック解放前）
+            let alert_on: std::collections::HashSet<PaneId> = store
+                .alerting_panes
+                .iter()
+                .filter(|(_, &count)| count > 0 && count % 2 == 0)
+                .map(|(&id, _)| id)
+                .collect();
             (
                 store.active,
                 store.scroll_offset,
@@ -678,6 +686,7 @@ mod win32 {
                 hsp,
                 fv,
                 hu,
+                alert_on,
             )
         };
 
@@ -977,6 +986,27 @@ mod win32 {
                 PADDING_X + sep.x + sep.w,
                 PADDING_Y + sep.y + sep.h,
             );
+        }
+
+        // ── アラートボーダー描画（通知受信ペインの枠線をアクセントカラーで描く）──
+        if !alert_on_panes.is_empty() {
+            let alert_color = state.theme.get().alert_border;
+            for (pane_id, rect) in &pane_rects {
+                if alert_on_panes.contains(pane_id) {
+                    let x0 = PADDING_X + rect.x;
+                    let y0 = PADDING_Y + rect.y;
+                    let x1 = x0 + rect.w;
+                    let y1 = y0 + rect.h;
+                    let pen = CreatePen(PS_SOLID, 2, alert_color);
+                    let old_pen = SelectObject(mem_dc, pen.into());
+                    let null_brush = GetStockObject(NULL_BRUSH);
+                    let old_brush = SelectObject(mem_dc, null_brush);
+                    let _ = Rectangle(mem_dc, x0, y0, x1, y1);
+                    SelectObject(mem_dc, old_pen);
+                    SelectObject(mem_dc, old_brush);
+                    let _ = DeleteObject(pen.into());
+                }
+            }
         }
 
         // ── フローティングペイン ─────────────────────────────────────
@@ -3137,7 +3167,7 @@ pub fn run_window(
     >,
     _float_tx: tokio::sync::mpsc::Sender<()>,
     _layout_tx: tokio::sync::mpsc::Sender<String>,
-    _theme: Theme,
+    _theme: crate::Theme,
     _news_scroll_px_per_tick: i32,
     _app_version: &'static str,
 ) -> anyhow::Result<()> {

--- a/crates/client/src/window/render.rs
+++ b/crates/client/src/window/render.rs
@@ -53,6 +53,9 @@ fn rgb_hex(v: u32) -> COLORREF {
     rgb(r, g, b)
 }
 
+/// デフォルトのアラートボーダー色（#FF6B6B: 赤橙系）
+const COLOR_ALERT_BORDER: COLORREF = COLORREF(0x00_6B_6B_FF);
+
 /// Win32 用に解決済みのテーマ色。
 #[derive(Copy, Clone)]
 pub(crate) struct WinTheme {
@@ -61,6 +64,8 @@ pub(crate) struct WinTheme {
     pub(crate) cursor: COLORREF,
     pub(crate) selection_bg: COLORREF,
     pub(crate) status_bar_bg: COLORREF,
+    /// 通知アラート時のペインボーダー色
+    pub(crate) alert_border: COLORREF,
 }
 
 impl WinTheme {
@@ -77,6 +82,10 @@ impl WinTheme {
                 .status_bar_bg
                 .map(rgb_hex)
                 .unwrap_or(COLORREF(0x00_25_18_18)),
+            alert_border: theme
+                .alert_border
+                .map(rgb_hex)
+                .unwrap_or(COLOR_ALERT_BORDER),
         }
     }
 }

--- a/crates/client/src/window/win32/wndproc.rs
+++ b/crates/client/src/window/win32/wndproc.rs
@@ -300,6 +300,16 @@ pub(super) unsafe fn handle_wm_timer(
             }
         }
 
+        // ── ペインアラート（ボーダー点滅）────────────────────────────────────
+        // アクティブペインのアラートを解除し、フリップカウントを進める。
+        // アラート中のペインが残っていれば再描画を要求する。
+        let has_alerting = {
+            let mut store = state.panes.lock().unwrap();
+            let active = store.active;
+            store.clear_alert(active);
+            store.tick_alert()
+        };
+
         // カーソル行を常に dirty に（永続バックバッファ上のカーソル描画を毎フレーム更新）
         {
             let store = state.panes.lock().unwrap();
@@ -394,7 +404,7 @@ pub(super) unsafe fn handle_wm_timer(
             dirty || state.ime.state.lock().unwrap().composing
         };
 
-        if needs_content_repaint || has_active_toasts {
+        if needs_content_repaint || has_active_toasts || has_alerting {
             let content_rect = RECT {
                 left: 0,
                 top: 0,

--- a/docs/tasks/active.md
+++ b/docs/tasks/active.md
@@ -421,6 +421,32 @@ yatamux ペインのシェルから `yatamux update` を実行すると exit cod
 - [x] `SaveAndQuit` 送信失敗と「yatamux ペイン内なのに IPC 接続失敗」の分岐を明示エラー化し、誤った自己置換フォールバックを止める
 - [ ] IPC 接続 / `SaveAndQuit` / `--apply-update` / ダウンロード検証のどこで落ちるかを切り分ける
 
+### C-41: 通知時のペインボーダーアクセントカラー + 点滅 【優先度: 中】
+
+tmux / cmux のように、バックグラウンドペインで通知が発生したとき OS のトースト通知（Windows Action Center）を送りつつ、
+該当ペインの枠線をアクセントカラーに切り替えて数回点滅させる視覚フィードバックを追加する。
+
+- **概要**:
+  1. **OS 通知**: 既存の `NativeToast` キュー（非フォーカス時）に加え、フォーカス中でも OS Action Center へ通知を送るオプションを追加する。発火トリガーは既存の BEL / OSC 9/99/777 / PTY 終了通知フローをそのまま流用する。
+  2. **ペインボーダー点滅**: 通知を受けたペインの ID を `alerting_panes: HashMap<PaneId, u8>` で管理し、残り点滅回数をカウントダウンする。`WM_TIMER` 16ms ティックでカウントを進め、0 になったら通常色に戻す。点滅の ON/OFF 切り替えは 200〜300ms 間隔（約 4〜5 ティックに 1 回）とする。
+  3. **アクセントカラー**: `AppearanceConfig` に `alert_border: Option<String>`（デフォルト `#FF6B6B` = 赤橙系）を追加し、`config.toml` の `[appearance]` セクションで上書き可能にする。
+  4. **点滅回数**: デフォルト 5 回（ON/OFF の対で 10 フリップ）。将来的に設定化できるよう `alert_blink_count` をコード上定数で管理する。
+
+- **変更クレート**: `yatamux-client`（`layout.rs`, `window.rs`, `config.rs`, `render/` 周辺）、`yatamux-protocol`（必要に応じて）
+- **テスト計画**: `docs/test-plan-pane-alert.md`
+
+#### サブタスク
+
+- [x] `docs/test-plan-pane-alert.md` を作成してテストケースを列挙する
+- [x] `AppearanceConfig` に `alert_border: Option<String>` を追加し、`parse_hex_color` でデフォルト `#FF6B6B` にフォールバックする
+- [x] `PaneStore` に `alerting_panes: HashMap<PaneId, u8>`（残りフリップ数）と `alert_tick: u8`（点滅タイマー用サブカウンタ）を追加する
+- [x] `AlertingBackend<I>` を `notification.rs` に追加し、`notify()` で `trigger_alert` を呼んだ後に内部バックエンドへ委譲する。`app.rs` で `FocusAwareBackend` をラップして接続する
+- [x] `WM_TIMER` ハンドラで `clear_alert(active)` を呼び、`tick_alert()` でフリップカウントをデクリメント → 0 になったエントリを削除して `InvalidateRect` を要求する
+- [x] `paint()` のセパレーター描画後に `alerting_panes` を参照し、点滅 ON フェーズなら `alert_border` 色で 2px ペインボーダーを描画する
+- [ ] フォーカス中でも OS Action Center へ `ShellExecute` / `Windows.UI.Notifications` 相当の API で送信する経路を追加する（既存 `NativeToast` のフォーカス条件を外すか別送信パスを設ける）
+- [x] `tests/e2e_smoke.rs` に BEL / ProcessExit / OSC 9 の通知 E2E テストを 3 本追加する（CI `windows-latest` で実機実行）
+- [x] 修正後に Clippy・全テスト・rustfmt を通す
+
 ## ドキュメント
 
 ### D-2: IPC / Agent 運用ドキュメント再整理 【優先度: 中】

--- a/docs/test-plan-pane-alert.md
+++ b/docs/test-plan-pane-alert.md
@@ -1,0 +1,173 @@
+## テスト計画: ペインアラート（C-41）
+
+通知受信時にペインボーダーをアクセントカラーで点滅させる機能のテスト計画。
+Ubuntu 上で `cargo test -p yatamux-client` および `cargo test` で実行できるものを中心に列挙する。
+
+---
+
+### 設定（config.rs）
+
+#### TC-C41-01: `[appearance] alert_border` フィールドを読み込める
+- **前提**: `config.toml` に `[appearance]\nalert_border = "#FF0000"` を記述
+- **操作**: `AppConfig::load()` で読み込む
+- **期待結果**: `appearance.alert_border == Some("#FF0000")`
+
+#### TC-C41-02: `alert_border` を省略するとデフォルト（`None`）になる
+- **前提**: `config.toml` に `[appearance]` セクションがない、または `alert_border` キーがない
+- **操作**: `AppConfig::load()` で読み込む
+- **期待結果**: `appearance.alert_border == None`
+
+---
+
+### アラート状態管理（store.rs）
+
+#### TC-C41-10: `trigger_alert` でペインが `alerting_panes` に追加される
+- **前提**: `PaneStore::new(PaneId(1), ...)`
+- **操作**: `store.trigger_alert(PaneId(2))`
+- **期待結果**: `alerting_panes` に `PaneId(2)` が存在し、フリップ数 == `ALERT_FLIP_COUNT`
+
+#### TC-C41-11: 初期状態で `alerting_panes` は空
+- **前提**: `PaneStore::new(...)`
+- **期待結果**: `store.alerting_panes.is_empty()`
+
+#### TC-C41-12: トリガー直後は `is_alert_on` が `true`
+- **前提**: `trigger_alert(PaneId(1))` 後
+- **期待結果**: `store.is_alert_on(PaneId(1)) == true`
+
+#### TC-C41-13: 登録されていないペインの `is_alert_on` は `false`
+- **前提**: 初期状態
+- **期待結果**: `store.is_alert_on(PaneId(99)) == false`
+
+#### TC-C41-14: `tick_alert` を `ALERT_TICK_DIVISOR` 回呼ぶとフリップ数が 1 減る
+- **前提**: `trigger_alert(PaneId(1))` 後（count = `ALERT_FLIP_COUNT`）
+- **操作**: `tick_alert()` を `ALERT_TICK_DIVISOR` 回呼ぶ
+- **期待結果**: `alerting_panes[PaneId(1)] == ALERT_FLIP_COUNT - 1`
+
+#### TC-C41-15: `tick_alert` が `true` を返す間、アラート中のペインが存在する
+- **前提**: `trigger_alert(PaneId(1))` 後
+- **操作**: `tick_alert()` を 1 回呼ぶ
+- **期待結果**: 戻り値 == `true`
+
+#### TC-C41-16: フリップ数が 0 になるとペインが `alerting_panes` から除去される
+- **前提**: `trigger_alert(PaneId(1))` 後（count = `ALERT_FLIP_COUNT`）
+- **操作**: `tick_alert()` を `ALERT_TICK_DIVISOR * ALERT_FLIP_COUNT` 回呼ぶ
+- **期待結果**: `alerting_panes.is_empty() == true`、`is_alert_on(PaneId(1)) == false`
+
+#### TC-C41-17: 全フリップ完了後 `tick_alert` は `false` を返す
+- **前提**: `trigger_alert` 後にすべてのフリップを消費
+- **操作**: `tick_alert()` を `ALERT_TICK_DIVISOR * ALERT_FLIP_COUNT + 1` 回呼ぶ
+- **期待結果**: 最後の `tick_alert()` 戻り値 == `false`
+
+#### TC-C41-18: ON/OFF フェーズが交互に切り替わる
+- **前提**: `trigger_alert(PaneId(1))` 後（count = `ALERT_FLIP_COUNT`、偶数）
+- **操作**: `tick_alert()` を `ALERT_TICK_DIVISOR` 回呼ぶ（1フリップ進める）
+- **期待結果**: 最初は `is_alert_on == true`（偶数カウント）、フリップ後は `false`（奇数カウント）
+
+#### TC-C41-19: `clear_alert` でペインのアラートが即座に解除される
+- **前提**: `trigger_alert(PaneId(1))` 後
+- **操作**: `store.clear_alert(PaneId(1))`
+- **期待結果**: `is_alert_on(PaneId(1)) == false`、`alerting_panes.is_empty() == true`
+
+#### TC-C41-20: 複数ペインを同時にアラートできる
+- **前提**: `trigger_alert(PaneId(1))`、`trigger_alert(PaneId(2))`
+- **期待結果**: 両方 `is_alert_on == true`
+
+#### TC-C41-21: `clear_alert` は存在しないペインに対してパニックしない
+- **前提**: 初期状態
+- **操作**: `store.clear_alert(PaneId(99))`
+- **期待結果**: パニックなし
+
+#### TC-C41-22: `trigger_alert` を再トリガーするとフリップ数がリセットされる
+- **前提**: `trigger_alert(PaneId(1))` → 数回 `tick_alert()`
+- **操作**: `trigger_alert(PaneId(1))` を再度呼ぶ
+- **期待結果**: `alerting_panes[PaneId(1)] == ALERT_FLIP_COUNT`（リセット済み）
+
+---
+
+### AlertingBackend（notification.rs）
+
+#### TC-C41-30: `AlertingBackend::notify` で `trigger_alert` が呼ばれる
+- **前提**: `AlertingBackend::new(store, inner)` を構築
+- **操作**: `backend.notify(PaneId(2), "test".to_string())`
+- **期待結果**: `store.alerting_panes` に `PaneId(2)` が含まれる
+
+#### TC-C41-31: `AlertingBackend::notify` は内部バックエンドにも委譲する
+- **前提**: inner として `InternalToast` を使用
+- **操作**: `backend.notify(PaneId(2), "hello".to_string())`
+- **期待結果**: `store.pending_toasts.len() == 1`（InternalToast が追加）
+
+#### TC-C41-32: active ペインへの通知でも `trigger_alert` は呼ばれる
+- **前提**: `store.active = PaneId(1)`、`AlertingBackend` でラップ
+- **操作**: `backend.notify(PaneId(1), "msg".to_string())`
+- **期待結果**: `alerting_panes` に `PaneId(1)` が含まれる
+  （`notify_if_inactive` は呼ばない側なので実際には発火しないが、
+   `AlertingBackend` 自体は active チェックを行わない）
+
+---
+
+### テーマ統合（theme.rs / config.rs / app.rs）
+
+#### TC-C41-40: `Theme` に `alert_border` フィールドがある
+- **前提**: `Theme::default()`
+- **期待結果**: `theme.alert_border == None`
+
+#### TC-C41-41: `build_theme` が `appearance.alert_border` を `Theme.alert_border` に変換する
+- **前提**: `AppearanceConfig { alert_border: Some("#ff6b6b".to_string()), .. }`
+- **操作**: `build_theme(&appearance)`
+- **期待結果**: `theme.alert_border == Some(0xFF6B6B)`
+
+---
+
+### E2E（`tests/e2e_smoke.rs` — CI の `windows-latest` で自動実行）
+
+#### TC-C41-60: BEL を bg ペインに送ると IPC Notification が届く
+- **テスト名**: `e2e_bel_on_background_pane_triggers_notification`
+- **前提**: 2 ペイン構成、root がアクティブ、bg がバックグラウンド
+- **操作**: `ClientMessage::Input { pane: bg, data: [0x07] }` を送信
+- **期待結果**: `ServerMessage::Notification { pane: bg, body: "Bell" }` が 10 秒以内に IPC ストリームに到着する
+- **検証内容**: `notify_if_inactive` の bg != active パスが通ること、通知文字列が正確であること
+
+#### TC-C41-61: bg ペインでプロセス終了すると Notification が届く
+- **テスト名**: `e2e_process_exit_on_background_pane_triggers_notification`
+- **前提**: 2 ペイン構成、root がアクティブ
+- **操作**: bg ペインで `exit\r` を送り cmd.exe を終了させる
+- **期待結果**: `ServerMessage::Notification { pane: bg, body: "Process exited" }` が 15 秒以内に到着する
+
+#### TC-C41-62: OSC 9 を bg ペインに送ると Notification が届く
+- **テスト名**: `e2e_osc9_on_background_pane_triggers_notification`
+- **前提**: 2 ペイン構成、root がアクティブ
+- **操作**: `\x1b]9;e2e-osc9-test\x07` を bg ペインに送信
+- **期待結果**: `ServerMessage::Notification { pane: bg, body: "e2e-osc9-test" }` が 10 秒以内に到着する
+
+> **CI との対応**: E2E ワークフロー（`.github/workflows/e2e.yml`）は `runs-on: windows-latest` で動作しており、
+> 上記テストは `cargo test --test e2e_smoke -- --ignored --test-threads=1` で実際の Windows 上で実行される。
+> Win32 アラートボーダー描画（TC-C41-50〜54）はヘッドレス環境で検証できないため手動テスト扱いとする。
+
+---
+
+### 描画（Windows 実機テスト）
+
+以下は Win32 環境でのみ実施する手動テスト。Ubuntu での自動化対象外。
+
+#### TC-C41-50（手動）: 非アクティブペインで通知発生時にボーダーが点滅する
+- **前提**: 2 ペイン以上の状態でペイン 2 をバックグラウンドにする
+- **操作**: ペイン 2 で BEL（`echo -e "\a"`）を発生させる
+- **期待結果**: ペイン 2 の枠線が `#FF6B6B`（またはカスタム色）で数秒間点滅し、その後消える
+
+#### TC-C41-51（手動）: アクティブになると点滅が停まる
+- **前提**: TC-C41-50 の状態で点滅中
+- **操作**: 点滅中のペインをクリックまたはペインモードでフォーカスを移す
+- **期待結果**: 次の WM_TIMER ティック（≈16ms）以内に点滅が消える
+
+#### TC-C41-52（手動）: `config.toml` の `alert_border` が反映される
+- **前提**: `[appearance]\nalert_border = "#00FF00"` で起動
+- **操作**: BEL を発火
+- **期待結果**: ペイン枠線が緑（#00FF00）で点滅する
+
+#### TC-C41-53（手動）: `alert_border` 省略時はデフォルト色（#FF6B6B）で点滅する
+- **前提**: `config.toml` に `alert_border` なし
+- **期待結果**: 赤橙色でボーダーが点滅する
+
+#### TC-C41-54（手動）: OS Action Center 通知が届く
+- **前提**: Windows フォーカス状態のまま非アクティブペインで通知発生
+- **期待結果**: Windows 通知センターにバルーンが表示される

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,9 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use tokio::sync::mpsc;
 
-use yatamux_client::{run_window, FocusAwareBackend, NotificationBackend, PaneStore, Theme};
+use yatamux_client::{
+    run_window, AlertingBackend, FocusAwareBackend, NotificationBackend, PaneStore, Theme,
+};
 use yatamux_protocol::types::{PaneId, SplitDirection, TermSize};
 use yatamux_protocol::ClientMessage;
 use yatamux_terminal::TerminalSink;
@@ -75,6 +77,7 @@ fn build_theme(appearance: &AppearanceConfig) -> Theme {
         status_bar_bg: parse(&appearance.status_bar_bg),
         font_family: appearance.font_family.clone(),
         font_size: appearance.font_size,
+        alert_border: parse(&appearance.alert_border),
     }
 }
 
@@ -153,11 +156,14 @@ pub async fn run(
         Arc::new(Mutex::new(store))
     };
 
-    // ── 通知バックエンド（フォーカス状態に応じて切り替え）────────────────
+    // ── 通知バックエンド（フォーカス状態に応じて切り替え + ボーダーアラート）──
     let app_focused = Arc::new(AtomicBool::new(true));
-    let (notif_backend, native_notif_queue) =
+    let (focus_backend, native_notif_queue) =
         FocusAwareBackend::new(Arc::clone(&app_focused), Arc::clone(&pane_store));
-    let notif_backend: Arc<dyn NotificationBackend> = Arc::new(notif_backend);
+    let notif_backend: Arc<dyn NotificationBackend> = Arc::new(AlertingBackend::new(
+        Arc::clone(&pane_store),
+        focus_backend,
+    ));
 
     // ── 入力・リサイズ チャネル（Window → Server）───────────────────────
     let (msg_tx, mut msg_rx) = mpsc::channel::<ClientMessage>(64);

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,10 +160,8 @@ pub async fn run(
     let app_focused = Arc::new(AtomicBool::new(true));
     let (focus_backend, native_notif_queue) =
         FocusAwareBackend::new(Arc::clone(&app_focused), Arc::clone(&pane_store));
-    let notif_backend: Arc<dyn NotificationBackend> = Arc::new(AlertingBackend::new(
-        Arc::clone(&pane_store),
-        focus_backend,
-    ));
+    let notif_backend: Arc<dyn NotificationBackend> =
+        Arc::new(AlertingBackend::new(Arc::clone(&pane_store), focus_backend));
 
     // ── 入力・リサイズ チャネル（Window → Server）───────────────────────
     let (msg_tx, mut msg_rx) = mpsc::channel::<ClientMessage>(64);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1246,8 +1246,12 @@ pub async fn source_config(path: &str) -> anyhow::Result<()> {
 
     // 親ディレクトリを作成
     if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("設定ディレクトリを作成できませんでした: {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "設定ディレクトリを作成できませんでした: {}",
+                parent.display()
+            )
+        })?;
     }
 
     // 既存 config.toml があればバックアップ

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub struct AppearanceConfig {
     pub selection_bg: Option<String>,
     /// ステータスバー背景色（`"#rrggbb"` 形式）
     pub status_bar_bg: Option<String>,
+    /// 通知アラート時のペインボーダー色（`"#rrggbb"` 形式、省略時: `#FF6B6B`）
+    pub alert_border: Option<String>,
 }
 
 /// `"#rrggbb"` 形式の文字列を `(r, g, b)` に変換する。
@@ -287,5 +289,26 @@ mod tests {
         let config: AppConfig = toml::from_str("").unwrap();
         assert!(config.appearance.font_family.is_none());
         assert!(config.appearance.background.is_none());
+    }
+
+    // TC-C41-01: alert_border フィールドを読み込める
+    #[test]
+    fn test_load_alert_border_config() {
+        let dir = std::env::temp_dir().join("yatamux_alert_border_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "[appearance]\nalert_border = \"#FF0000\"\n").unwrap();
+
+        let config = AppConfig::load(&path).unwrap();
+        assert_eq!(config.appearance.alert_border.as_deref(), Some("#FF0000"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // TC-C41-02: alert_border を省略するとデフォルト（None）になる
+    #[test]
+    fn test_alert_border_default_is_none() {
+        let config: AppConfig = toml::from_str("[appearance]").unwrap();
+        assert!(config.appearance.alert_border.is_none());
     }
 }

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -1344,20 +1344,24 @@ fn e2e_bel_on_background_pane_triggers_notification() {
     // bg != active となり、BEL が notify_if_inactive を通過する。
     let bg = harness.split_pane(&root.0.to_string(), SplitDirection::Vertical, None);
     harness.wait_for_pane_count(2);
+    // bg ペインのシェルが起動するまで待つ（コマンドを受け付けられる状態にする）
+    harness.wait_for_shell_ready(&bg.0.to_string());
 
     harness.block_on(async {
         let mut conn = ServerConnection::connect(&harness.session)
             .await
             .expect("connect for alert BEL test");
 
-        // BEL (0x07) を bg ペインに直接送信
+        // PowerShell で BEL (0x07) を PTY 出力に書き出す。
+        // ClientMessage::Input は PTY stdin に書くため、cmd.exe がコマンドとして実行し
+        // PowerShell が [char]7 を stdout に出力 → VtProcessor が BEL を検出する。
         conn.tx
             .send(ClientMessage::Input {
                 pane: bg,
-                data: vec![0x07],
+                data: b"powershell -nop -c \"[Console]::Write([char]7)\"\r".to_vec(),
             })
             .await
-            .expect("send BEL to bg pane");
+            .expect("send BEL command to bg pane");
 
         // Notification が IPC ストリームに流れることを確認
         let body = wait_for_notification(&mut conn, bg, Duration::from_secs(10)).await;
@@ -1426,21 +1430,23 @@ fn e2e_osc9_on_background_pane_triggers_notification() {
     let root = harness.wait_for_pane_count(1)[0].id;
     let bg = harness.split_pane(&root.0.to_string(), SplitDirection::Vertical, None);
     harness.wait_for_pane_count(2);
+    // bg ペインのシェルが起動するまで待つ
+    harness.wait_for_shell_ready(&bg.0.to_string());
 
     harness.block_on(async {
         let mut conn = ServerConnection::connect(&harness.session)
             .await
             .expect("connect for OSC 9 test");
 
-        // OSC 9 通知シーケンス: ESC ] 9 ; <body> BEL
-        let osc9: Vec<u8> = b"\x1b]9;e2e-osc9-test\x07".to_vec();
+        // PowerShell で OSC 9 シーケンス（ESC ] 9 ; <body> BEL）を PTY 出力に書き出す。
+        // [string][char]27 = ESC、[string][char]7 = BEL をシングルクォート文字列と結合する。
         conn.tx
             .send(ClientMessage::Input {
                 pane: bg,
-                data: osc9,
+                data: b"powershell -nop -c \"[Console]::Write([string][char]27+']9;e2e-osc9-test'+[string][char]7)\"\r".to_vec(),
             })
             .await
-            .expect("send OSC 9 to bg pane");
+            .expect("send OSC 9 command to bg pane");
 
         let body = wait_for_notification(&mut conn, bg, Duration::from_secs(10)).await;
         assert_eq!(

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -625,7 +625,10 @@ async fn wait_for_notification(
                     return body;
                 }
                 Some(ServerMessage::Error { message }) => {
-                    panic!("unexpected error while waiting for notification: {}", message)
+                    panic!(
+                        "unexpected error while waiting for notification: {}",
+                        message
+                    )
                 }
                 Some(_) => continue,
                 None => panic!("connection closed before Notification arrived"),

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -610,6 +610,32 @@ fn collect_snapshot_leaves(node: &LayoutNodeDef, out: &mut Vec<SnapshotLeaf>) {
     }
 }
 
+/// 指定ペインへの `ServerMessage::Notification` を IPC ストリームから待つ。
+///
+/// 他のメッセージはスキップし、`timeout` 以内に到着しなければパニックする。
+async fn wait_for_notification(
+    conn: &mut ServerConnection,
+    target_pane: PaneId,
+    timeout: Duration,
+) -> String {
+    tokio::time::timeout(timeout, async {
+        loop {
+            match conn.rx.recv().await {
+                Some(ServerMessage::Notification { pane, body }) if pane == target_pane => {
+                    return body;
+                }
+                Some(ServerMessage::Error { message }) => {
+                    panic!("unexpected error while waiting for notification: {}", message)
+                }
+                Some(_) => continue,
+                None => panic!("connection closed before Notification arrived"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for Notification")
+}
+
 async fn wait_for_exec_result(
     conn: &mut ServerConnection,
     request_id: &str,
@@ -1293,4 +1319,133 @@ fn e2e_self_update_smoke_preserves_session_and_relaunches() {
     );
 
     harness.wait_for_ipc_unavailable(Duration::from_secs(20));
+}
+
+// ── C-41: 通知・アラート E2E ─────────────────────────────────────────────────
+
+/// バックグラウンドペインに BEL を送ると ServerMessage::Notification が届くことを確認する。
+///
+/// 検証内容:
+/// - IPC 経由で `ServerMessage::Notification { pane: bg, body: "Bell" }` が到着する
+/// - `notify_if_inactive` 経路（bg != active）が正しく通ること
+///
+/// Win32 アラートボーダーの点滅は視覚的 E2E であり、ここでは IPC 到達を検証する。
+#[test]
+#[ignore = "starts a real yatamux GUI process"]
+fn e2e_bel_on_background_pane_triggers_notification() {
+    let _guard = lock_e2e_tests();
+    let mut harness = AppHarness::new("yatamux-e2e-alert-bel");
+    harness.spawn();
+
+    // 起動待機 — initial pane が active (pane_store.active = root)
+    let root = harness.wait_for_pane_count(1)[0].id;
+
+    // IPC 分割で bg ペインを作成。IPC 起点では pane_store.active は変わらないため
+    // bg != active となり、BEL が notify_if_inactive を通過する。
+    let bg = harness.split_pane(&root.0.to_string(), SplitDirection::Vertical, None);
+    harness.wait_for_pane_count(2);
+
+    harness.block_on(async {
+        let mut conn = ServerConnection::connect(&harness.session)
+            .await
+            .expect("connect for alert BEL test");
+
+        // BEL (0x07) を bg ペインに直接送信
+        conn.tx
+            .send(ClientMessage::Input {
+                pane: bg,
+                data: vec![0x07],
+            })
+            .await
+            .expect("send BEL to bg pane");
+
+        // Notification が IPC ストリームに流れることを確認
+        let body = wait_for_notification(&mut conn, bg, Duration::from_secs(10)).await;
+        assert_eq!(
+            body, "Bell",
+            "BEL should produce Notification with body 'Bell', got: {body:?}"
+        );
+    });
+}
+
+/// バックグラウンドペインでプロセスが終了すると Notification が届くことを確認する。
+///
+/// 検証内容:
+/// - `cmd /c exit` を bg ペインで実行し PTY が閉じる
+/// - `ServerMessage::Notification { pane: bg, body: "Process exited" }` が IPC 到達する
+#[test]
+#[ignore = "starts a real yatamux GUI process"]
+fn e2e_process_exit_on_background_pane_triggers_notification() {
+    let _guard = lock_e2e_tests();
+    let mut harness = AppHarness::new("yatamux-e2e-alert-exit");
+    harness.spawn();
+
+    let root = harness.wait_for_pane_count(1)[0].id;
+
+    // bg ペイン作成（root が active のまま）
+    let bg = harness.split_pane(&root.0.to_string(), SplitDirection::Vertical, None);
+    harness.wait_for_pane_count(2);
+    // bg ペインのシェルが起動するまで待つ
+    harness.wait_for_shell_ready(&bg.0.to_string());
+
+    harness.block_on(async {
+        let mut conn = ServerConnection::connect(&harness.session)
+            .await
+            .expect("connect for alert exit test");
+
+        // bg ペインのシェル（cmd.exe）を終了させる
+        conn.tx
+            .send(ClientMessage::Input {
+                pane: bg,
+                data: b"exit\r".to_vec(),
+            })
+            .await
+            .expect("send exit to bg pane");
+
+        // PTY 終了通知が IPC に流れることを確認
+        let body = wait_for_notification(&mut conn, bg, Duration::from_secs(15)).await;
+        assert_eq!(
+            body, "Process exited",
+            "PTY exit should produce Notification 'Process exited', got: {body:?}"
+        );
+    });
+}
+
+/// OSC 9 通知文字列を bg ペインに送ると Notification が届くことを確認する。
+///
+/// 検証内容:
+/// - OSC 9 は tmux 互換の即時通知トリガー
+/// - `\x1b]9;hello\x07` → `ServerMessage::Notification { body: "hello" }`
+#[test]
+#[ignore = "starts a real yatamux GUI process"]
+fn e2e_osc9_on_background_pane_triggers_notification() {
+    let _guard = lock_e2e_tests();
+    let mut harness = AppHarness::new("yatamux-e2e-alert-osc9");
+    harness.spawn();
+
+    let root = harness.wait_for_pane_count(1)[0].id;
+    let bg = harness.split_pane(&root.0.to_string(), SplitDirection::Vertical, None);
+    harness.wait_for_pane_count(2);
+
+    harness.block_on(async {
+        let mut conn = ServerConnection::connect(&harness.session)
+            .await
+            .expect("connect for OSC 9 test");
+
+        // OSC 9 通知シーケンス: ESC ] 9 ; <body> BEL
+        let osc9: Vec<u8> = b"\x1b]9;e2e-osc9-test\x07".to_vec();
+        conn.tx
+            .send(ClientMessage::Input {
+                pane: bg,
+                data: osc9,
+            })
+            .await
+            .expect("send OSC 9 to bg pane");
+
+        let body = wait_for_notification(&mut conn, bg, Duration::from_secs(10)).await;
+        assert_eq!(
+            body, "e2e-osc9-test",
+            "OSC 9 should produce Notification with the message body, got: {body:?}"
+        );
+    });
 }


### PR DESCRIPTION
## Summary

- 通知（BEL / OSC 9/99/777 / PTY 終了）を受けたバックグラウンドペインの枠線をアクセントカラーで数回点滅させる視覚フィードバックを追加
- `AppearanceConfig` / `Theme` に `alert_border` フィールドを追加（デフォルト `#FF6B6B`、`config.toml` で上書き可能）
- `AlertingBackend<I>` でラップして通知受信時に常に `trigger_alert` を呼ぶ設計
- E2E テスト 3 本を追加し、`windows-latest` CI で BEL / ProcessExit / OSC 9 → IPC Notification 到達を実機検証

## Test plan

- [x] `cargo test -p yatamux-client` — 116 テスト全パス（アラート関連 15 本含む）
- [x] `cargo fmt --check -p yatamux-client`
- [x] `cargo check --test e2e_smoke` — シンタックスエラーなし
- [ ] CI (`windows-latest`) — E2E smoke + 通知 3 シナリオ

🤖 Generated with [Claude Code](https://claude.com/claude-code)