### PR TITLE
feat(protocol): add IPC handshake / protocol_version / capabilities (C-42)

### DIFF
--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
-use yatamux_protocol::{ClientMessage, ServerMessage};
+use yatamux_protocol::{ClientMessage, ServerMessage, PROTOCOL_VERSION, SERVER_CAPABILITIES};
 
 pub struct ServerConnection {
     pub tx: mpsc::Sender<ClientMessage>,
@@ -75,6 +75,18 @@ impl ServerConnection {
             let (reader, mut writer) = tokio::io::split(pipe);
             let mut lines = BufReader::new(reader).lines();
 
+            // 接続直後にプロトコルハンドシェイクを送信する
+            // 旧サーバーは未知メッセージとして warn して継続（後方互換）
+            let handshake = ClientMessage::Handshake {
+                protocol_version: PROTOCOL_VERSION,
+                capabilities: SERVER_CAPABILITIES.iter().map(|s| s.to_string()).collect(),
+            };
+            if let Ok(json) = serde_json::to_string(&handshake) {
+                let line = format!("{}\n", json);
+                // 送信失敗は致命的ではないので無視する（旧サーバーとの互換維持）
+                let _ = writer.write_all(line.as_bytes()).await;
+            }
+
             let (client_tx, mut client_rx) = mpsc::channel::<ClientMessage>(64);
             let (server_tx, server_rx) = mpsc::channel::<ServerMessage>(64);
 
@@ -91,9 +103,13 @@ impl ServerConnection {
             });
 
             // パイプ読み取り → サーバーメッセージチャネルタスク
+            // HandshakeAccepted はプロトコル層で処理済みのため上位に転送しない
             tokio::spawn(async move {
                 while let Ok(Some(line)) = lines.next_line().await {
                     if let Ok(msg) = serde_json::from_str::<ServerMessage>(&line) {
+                        if matches!(msg, ServerMessage::HandshakeAccepted { .. }) {
+                            continue;
+                        }
                         if server_tx.send(msg).await.is_err() {
                             break;
                         }

--- a/crates/client/src/window/win32/wndproc.rs
+++ b/crates/client/src/window/win32/wndproc.rs
@@ -315,7 +315,7 @@ pub(super) unsafe fn handle_wm_timer(
         // ── sysinfo（CPU/RAM）は 60 フレームごと（≈1秒）に更新 ───────────────
         let tick = state.sysinfo_tick.get().wrapping_add(1);
         state.sysinfo_tick.set(tick);
-        let sysinfo_updated = tick % 60 == 0;
+        let sysinfo_updated = tick.is_multiple_of(60);
         if sysinfo_updated {
             // CPU 使用率（GetSystemTimes デルタ）
             let mut idle = windows::Win32::Foundation::FILETIME::default();
@@ -365,7 +365,9 @@ pub(super) unsafe fn handle_wm_timer(
             state.news_scroll_px_per_tick > 0 && !state.news_text_cache.borrow().is_empty();
         if ticker_active {
             let cur = state.news_scroll_px.get();
-            state.news_scroll_px.set(cur + state.news_scroll_px_per_tick);
+            state
+                .news_scroll_px
+                .set(cur + state.news_scroll_px_per_tick);
         }
 
         // ── ステータスバーの dirty 判定 ──────────────────────────────────────
@@ -393,11 +395,21 @@ pub(super) unsafe fn handle_wm_timer(
         };
 
         if needs_content_repaint || has_active_toasts {
-            let content_rect = RECT { left: 0, top: 0, right: win_w, bottom: bar_y.max(0) };
+            let content_rect = RECT {
+                left: 0,
+                top: 0,
+                right: win_w,
+                bottom: bar_y.max(0),
+            };
             let _ = InvalidateRect(Some(hwnd), Some(&content_rect), false);
         }
         if status_dirty || has_active_toasts {
-            let sb_rect = RECT { left: 0, top: bar_y.max(0), right: win_w, bottom: win_h };
+            let sb_rect = RECT {
+                left: 0,
+                top: bar_y.max(0),
+                right: win_w,
+                bottom: win_h,
+            };
             let _ = InvalidateRect(Some(hwnd), Some(&sb_rect), false);
         }
     }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -32,6 +32,21 @@ pub mod message;
 pub mod types;
 
 pub use message::{ClientMessage, ServerMessage};
+
+/// 現在のプロトコルバージョン（サーバー側）
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// サーバーが受け入れる最小クライアントバージョン
+pub const MIN_CLIENT_VERSION: u32 = 1;
+
+/// サーバーが宣言する capabilities
+pub const SERVER_CAPABILITIES: &[&str] = &[
+    "subscribe_pane",
+    "exec",
+    "capture_pane",
+    "alias_role",
+    "session_save",
+];
 pub use types::{
     CursorInfo, PaneCapture, PaneId, PaneInfo, SplitDirection, SurfaceId, TermSize, WorkspaceId,
 };
@@ -83,6 +98,8 @@ mod tests {
             last_output_unix_ms: Some(1_744_000_000_000),
             active: true,
             floating: false,
+            alias: None,
+            role: None,
         };
         assert_eq!(info.id, PaneId(3));
         assert_eq!(info.cols, 120);

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -116,6 +116,18 @@ pub enum ClientMessage {
 
     /// 全ペインで実際に動いている子プロセス名を問い合わせる
     QueryAllPaneProcesses,
+
+    /// IPC 接続確立直後に送るプロトコルハンドシェイク要求
+    ///
+    /// クライアントは接続後すぐにこのメッセージを送信する。
+    /// 旧サーバーは未知メッセージとして warn して継続（後方互換）。
+    Handshake {
+        /// クライアントのプロトコルバージョン
+        protocol_version: u32,
+        /// クライアントがサポートする capabilities
+        #[serde(default)]
+        capabilities: Vec<String>,
+    },
 }
 
 /// サーバー → クライアント メッセージ
@@ -219,6 +231,19 @@ pub enum ServerMessage {
         /// 各ペインの現在の作業ディレクトリ（None = 取得不可）
         #[serde(default)]
         cwds: HashMap<String, Option<String>>,
+    },
+
+    /// ClientMessage::Handshake への応答
+    ///
+    /// サーバーのプロトコルバージョンと capabilities を伝える。
+    HandshakeAccepted {
+        /// サーバーのプロトコルバージョン
+        protocol_version: u32,
+        /// サーバーがサポートする minimum client version
+        min_client_version: u32,
+        /// サーバーの capabilities
+        #[serde(default)]
+        capabilities: Vec<String>,
     },
 }
 

--- a/crates/server/src/ipc.rs
+++ b/crates/server/src/ipc.rs
@@ -10,7 +10,9 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, info, warn};
 
 use yatamux_protocol::types::PaneId;
-use yatamux_protocol::{ClientMessage, ServerMessage};
+use yatamux_protocol::{
+    ClientMessage, ServerMessage, MIN_CLIENT_VERSION, PROTOCOL_VERSION, SERVER_CAPABILITIES,
+};
 
 /// 名前付きパイプのベース名
 pub const PIPE_PREFIX: &str = r"\\.\pipe\yatamux-";
@@ -171,6 +173,44 @@ async fn handle_client(
                             Ok(msg) => {
                                 debug!("IPC recv: {:?}", msg);
                                 match msg {
+                                    ClientMessage::Handshake {
+                                        protocol_version,
+                                        capabilities,
+                                    } => {
+                                        if protocol_version < MIN_CLIENT_VERSION {
+                                            warn!(
+                                                "IPC: client protocol version {} is below minimum {}; disconnecting",
+                                                protocol_version, MIN_CLIENT_VERSION,
+                                            );
+                                            let err_msg = ServerMessage::Error {
+                                                message: format!(
+                                                    "client protocol version {} is not supported (minimum: {}); please upgrade yatamux",
+                                                    protocol_version, MIN_CLIENT_VERSION,
+                                                ),
+                                            };
+                                            let _ =
+                                                write_server_message(&mut writer, &err_msg).await;
+                                            break;
+                                        }
+                                        info!(
+                                            "IPC: handshake from client v{}, capabilities: {:?}",
+                                            protocol_version, capabilities
+                                        );
+                                        let accepted = ServerMessage::HandshakeAccepted {
+                                            protocol_version: PROTOCOL_VERSION,
+                                            min_client_version: MIN_CLIENT_VERSION,
+                                            capabilities: SERVER_CAPABILITIES
+                                                .iter()
+                                                .map(|s| s.to_string())
+                                                .collect(),
+                                        };
+                                        if write_server_message(&mut writer, &accepted)
+                                            .await
+                                            .is_err()
+                                        {
+                                            break;
+                                        }
+                                    }
                                     ClientMessage::SubscribePane { pane } => {
                                         subscriptions.insert(pane);
                                     }

--- a/crates/server/src/session/handlers/mod.rs
+++ b/crates/server/src/session/handlers/mod.rs
@@ -66,6 +66,8 @@ impl Server {
                 Ok(())
             }
             ClientMessage::QueryAllPaneProcesses => self.handle_query_all_pane_processes().await,
+            // Handshake は IPC 層で処理済みのため、ここには到達しない
+            ClientMessage::Handshake { .. } => Ok(()),
         }
     }
 

--- a/docs/test-plan-ipc-protocol.md
+++ b/docs/test-plan-ipc-protocol.md
@@ -1,0 +1,26 @@
+## テスト計画: IPC プロトコル固定化
+
+### TC-01: handshake 成功
+- **前提**: IPC 接続直後にクライアントが `protocol_version` と `capabilities` を含む handshake 要求を送れる
+- **操作**: サポート対象バージョンと既知 capability を持つ handshake 要求を 1 本の名前付きパイプ接続で送信する
+- **期待結果**: サーバーが handshake 成功応答を返し、その後の `ListPanes` など通常要求を同一接続で処理できる
+
+### TC-02: `protocol_version` 不一致
+- **前提**: サーバーが受理可能な protocol version 範囲を持つ
+- **操作**: 非対応の `protocol_version` を含む handshake 要求を送信する
+- **期待結果**: サーバーは接続を黙殺せず、非対応バージョン・受理可能範囲・再試行指針を含む明示エラーを返す
+
+### TC-03: capability 不足
+- **前提**: handshake で capability 交渉を行い、要求側と応答側の capability 集合を比較できる
+- **操作**: クライアントが必要 capability を宣言し、サーバー側がその一部を持たない状態で handshake または該当 request を送信する
+- **期待結果**: サーバーは不足 capability 名を含む失敗応答を返し、未サポート機能だけを拒否するか接続全体を拒否するかの方針が仕様どおりに固定される
+
+### TC-04: error envelope
+- **前提**: request / response 系メッセージに `request_id` を持つ error envelope 型が定義されている
+- **操作**: `request_id` 付き request を送信し、サーバー側でバリデーションエラーまたは実行エラーを発生させる
+- **期待結果**: 応答は `request_id` を保持した失敗形式で返り、成功応答と同じ相関キーで多重化接続上の caller が対象 request の失敗だけを識別できる
+
+### TC-05: 旧クライアントとの後方互換
+- **前提**: handshake 未実装の旧クライアント互換モードを残す方針がある
+- **操作**: 接続直後に handshake を送らず、現行どおり最初の `ListPanes` または `CapturePane` を送信する
+- **期待結果**: サーバーは legacy client として扱うか、許容期間付きの互換モードへ自動遷移し、既存 CLI が handshake なしでも破壊的変更なく動作する


### PR DESCRIPTION
## Summary

- `yatamux-protocol` に `PROTOCOL_VERSION` / `MIN_CLIENT_VERSION` / `SERVER_CAPABILITIES` 定数を追加
- `ClientMessage::Handshake { protocol_version, capabilities }` を追加
  - クライアントは接続直後に送信する（旧サーバーは未知メッセージとして warn → 継続で後方互換）
- `ServerMessage::HandshakeAccepted { protocol_version, min_client_version, capabilities }` を追加
- `ipc.rs` `handle_client`: `Handshake` 受信時にバージョンチェックし `HandshakeAccepted` を返す
  - `protocol_version < MIN_CLIENT_VERSION` の場合は `Error` 送信後に切断
- `connection.rs`: 接続直後に `ClientMessage::Handshake` を送信
  - `HandshakeAccepted` は接続層で吸収し、上位 CLI / テストには転送しない（後方互換）
- `docs/test-plan-ipc-protocol.md` を追加（TC-01〜TC-05）
- `wndproc.rs`: `clippy::manual_is_multiple_of` 既存 lint を修正

## 後方互換

| パターン | 動作 |
|---|---|
| 新サーバー + 新クライアント | Handshake 交換、バージョン確認 |
| 新サーバー + 旧クライアント | Handshake なしのまま動作継続（レガシーモード） |
| 旧サーバー + 新クライアント | サーバー側で未知メッセージを warn して継続 |

## 残課題（C-42 続編）

- TC-02 version 不一致の自動テスト（E2E で確認が必要）
- `exec` / `wait-pane` / `subscribe-pane` を横断した `request_id` / 失敗エラーの統一（`docs/protocol-ipc.md` の整備）
- 旧新 CLI 互換 golden fixture の追加

## Test plan

- [x] `cargo clippy -p yatamux-protocol -p yatamux-server -p yatamux-client -- -D warnings`: 警告なし
- [x] `cargo test -p yatamux-protocol -p yatamux-server -p yatamux-client`: 全パス（`test_exec_request_returns_completed_result_with_request_id` は master でも発生する既存 flaky のため除く）
- [x] `cargo fmt --check -p yatamux-protocol -p yatamux-server -p yatamux-client`: フォーマット確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)