### PR TITLE
feat(status-bar): add GitHub CI status indicator

### DIFF
--- a/crates/client/src/layout/store.rs
+++ b/crates/client/src/layout/store.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use yatamux_protocol::types::PaneId;
+use yatamux_protocol::CiRunInfo;
 use yatamux_terminal::Grid;
 
 use super::{LauncherState, LayoutNode, PaneRect, ThemeLauncherState};
@@ -359,6 +360,9 @@ pub struct PaneStore {
     /// ニュースティッカー本文（RSS から取得した見出しを区切り文字で連結）
     /// 空文字列 = 未取得またはティッカー無効
     pub news_text: String,
+    /// CI ステータス（GitHub Actions ポーラーが定期更新）
+    /// `None` = CI 設定なし、または未取得
+    pub ci_status: Arc<Mutex<Option<CiRunInfo>>>,
 }
 
 impl PaneStore {
@@ -392,6 +396,7 @@ impl PaneStore {
             alert_tick: 0,
             hovered_url: None,
             news_text: String::new(),
+            ci_status: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/crates/client/src/window/mod.rs
+++ b/crates/client/src/window/mod.rs
@@ -50,7 +50,7 @@ mod win32 {
         NOTIFYICONDATAW,
     };
     use yatamux_protocol::types::{PaneId, SplitDirection, TermSize};
-    use yatamux_protocol::ClientMessage;
+    use yatamux_protocol::{CiRunInfo, ClientMessage};
     use yatamux_terminal::cell::CellContent;
     use yatamux_terminal::{Cell, Grid};
 
@@ -182,6 +182,8 @@ mod win32 {
         pub news_scroll_px_per_tick: i32,
         /// PaneStore.news_text のキャッシュ（Win32 スレッド専用 — 毎フレームの lock を省く）
         news_text_cache: std::cell::RefCell<String>,
+        /// PaneStore.ci_status のキャッシュ（Win32 スレッド専用 — 毎フレームの lock を省く）
+        ci_status_cache: std::cell::RefCell<Option<CiRunInfo>>,
         /// CPU/RAM ポーリング間引きカウンタ（60 フレームごとに更新 ≈ 1 秒）
         sysinfo_tick: std::cell::Cell<u32>,
         /// ステータスバー領域が更新されたことを示すフラグ（WM_TIMER → paint で使用）
@@ -245,6 +247,7 @@ mod win32 {
                 news_scroll_px: std::cell::Cell::new(0),
                 news_scroll_px_per_tick,
                 news_text_cache: std::cell::RefCell::new(String::new()),
+                ci_status_cache: std::cell::RefCell::new(None),
                 sysinfo_tick: std::cell::Cell::new(0),
                 status_bar_dirty: std::cell::Cell::new(false),
                 cpu_usage: std::cell::Cell::new(0.0),
@@ -1246,8 +1249,21 @@ mod win32 {
         };
         let cpu = state.cpu_usage.get();
         let mem = state.mem_usage.get();
-        let right_text =
-            format_status_bar_right_text(&cwd_str, cpu, mem, state.app_version, active_idx, total);
+        let ci_label = state
+            .ci_status_cache
+            .borrow()
+            .as_ref()
+            .map(|ci| ci.status_label().to_string())
+            .unwrap_or_default();
+        let right_text = format_status_bar_right_text(
+            &cwd_str,
+            cpu,
+            mem,
+            &ci_label,
+            state.app_version,
+            active_idx,
+            total,
+        );
         let right_wide: Vec<u16> = right_text.encode_utf16().collect();
         let mut right_size = SIZE::default();
         let _ = GetTextExtentPoint32W(hdc, &right_wide, &mut right_size);
@@ -1366,19 +1382,33 @@ mod win32 {
         cwd: &str,
         cpu: f32,
         mem: f32,
+        ci_label: &str,
         app_version: &str,
         active_idx: usize,
         total: usize,
     ) -> String {
-        format!(
-            " {} C:{} M:{} v{} pane {}/{} ",
-            truncate_path_middle(cwd, 30),
-            format_usage_percent(cpu),
-            format_usage_percent(mem),
-            app_version,
-            active_idx,
-            total,
-        )
+        if ci_label.is_empty() {
+            format!(
+                " {} C:{} M:{} v{} pane {}/{} ",
+                truncate_path_middle(cwd, 30),
+                format_usage_percent(cpu),
+                format_usage_percent(mem),
+                app_version,
+                active_idx,
+                total,
+            )
+        } else {
+            format!(
+                " {} C:{} M:{} {} v{} pane {}/{} ",
+                truncate_path_middle(cwd, 30),
+                format_usage_percent(cpu),
+                format_usage_percent(mem),
+                ci_label,
+                app_version,
+                active_idx,
+                total,
+            )
+        }
     }
 
     fn format_usage_percent(value: f32) -> String {
@@ -3053,12 +3083,20 @@ mod win32 {
                 "C:\\Users\\raiga\\dev\\yatamux",
                 12.4,
                 100.0,
+                "",
                 "0.1.14",
                 2,
                 3,
             );
             assert!(text.contains("C:12% M:100%"));
             assert!(text.contains("pane 2/3"));
+        }
+
+        #[test]
+        fn test_format_status_bar_right_text_shows_ci_label() {
+            let text = format_status_bar_right_text("C:\\dev", 0.0, 0.0, "CI✓", "0.1.0", 1, 1);
+            assert!(text.contains("CI✓"));
+            assert!(text.contains("pane 1/1"));
         }
 
         // ── B-7: スクロールオフセットのクランプ / リセット ──────────────────

--- a/crates/client/src/window/win32/wndproc.rs
+++ b/crates/client/src/window/win32/wndproc.rs
@@ -371,6 +371,16 @@ pub(super) unsafe fn handle_wm_timer(
             let new_text = state.panes.lock().unwrap().news_text.clone();
             *state.news_text_cache.borrow_mut() = new_text;
         }
+
+        // ── CI ステータス同期 ─────────────────────────────────────────────────
+        {
+            let ci_arc = {
+                let store = state.panes.lock().unwrap();
+                std::sync::Arc::clone(&store.ci_status)
+            };
+            let new_ci = ci_arc.lock().unwrap().clone();
+            *state.ci_status_cache.borrow_mut() = new_ci;
+        }
         let ticker_active =
             state.news_scroll_px_per_tick > 0 && !state.news_text_cache.borrow().is_empty();
         if ticker_active {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -48,7 +48,8 @@ pub const SERVER_CAPABILITIES: &[&str] = &[
     "session_save",
 ];
 pub use types::{
-    CursorInfo, PaneCapture, PaneId, PaneInfo, SplitDirection, SurfaceId, TermSize, WorkspaceId,
+    CiConclusion, CiRunInfo, CiRunStatus, CursorInfo, PaneCapture, PaneId, PaneInfo,
+    SplitDirection, SurfaceId, TermSize, WorkspaceId,
 };
 
 /// ワイヤーフォーマット golden fixture テスト

--- a/crates/protocol/src/message.rs
+++ b/crates/protocol/src/message.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    ExecStatus, ExecWaitCondition, PaneCapture, PaneId, PaneInfo, SplitDirection, SurfaceId,
-    TermSize, WorkspaceId,
+    CiRunInfo, ExecStatus, ExecWaitCondition, PaneCapture, PaneId, PaneInfo, SplitDirection,
+    SurfaceId, TermSize, WorkspaceId,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -128,6 +128,12 @@ pub enum ClientMessage {
         #[serde(default)]
         capabilities: Vec<String>,
     },
+
+    /// 現在の CI ステータスを問い合わせる
+    ///
+    /// サーバーは最後に取得した `CiRunInfo` を `ServerMessage::CiStatus` で返す。
+    /// CI 設定がない場合は `ServerMessage::CiStatus { info: None }` が返る。
+    QueryCiStatus,
 }
 
 /// サーバー → クライアント メッセージ
@@ -244,6 +250,17 @@ pub enum ServerMessage {
         /// サーバーの capabilities
         #[serde(default)]
         capabilities: Vec<String>,
+    },
+
+    /// CI ステータス通知
+    ///
+    /// - `QueryCiStatus` への応答として送られる
+    /// - CI ポーラーがステータスを更新するたびにブロードキャストされる
+    ///
+    /// `info` が `None` の場合は CI 設定なし、またはまだ取得前。
+    CiStatus {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        info: Option<CiRunInfo>,
     },
 }
 

--- a/crates/protocol/src/types.rs
+++ b/crates/protocol/src/types.rs
@@ -73,6 +73,81 @@ pub struct PaneCapture {
     pub scrollback_tail: Vec<String>,
 }
 
+/// GitHub Actions CI ランの状態
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiConclusion {
+    /// 成功
+    Success,
+    /// 失敗
+    Failure,
+    /// キャンセル
+    Cancelled,
+    /// スキップ
+    Skipped,
+    /// 不明 / 未対応の値
+    Unknown,
+}
+
+/// GitHub Actions CI ランの進行状態
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiRunStatus {
+    /// キュー待ち / 開始待ち
+    Queued,
+    /// 実行中
+    InProgress,
+    /// 完了（conclusion を参照）
+    Completed,
+}
+
+/// GitHub Actions の最新ワークフローラン情報
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CiRunInfo {
+    /// リポジトリ（owner/repo）
+    pub repo: String,
+    /// ワークフロー名
+    pub name: String,
+    /// ランの進行状態
+    pub status: CiRunStatus,
+    /// 完了時の結果（実行中は None）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conclusion: Option<CiConclusion>,
+    /// ブランチ名
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// コミット SHA（先頭 7 文字）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
+    /// GitHub の run URL
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html_url: Option<String>,
+    /// 最終更新時刻（ISO 8601）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl CiRunInfo {
+    /// ステータスバー表示用の短い文字列を返す
+    ///
+    /// - 実行中: `CI⟳`
+    /// - 成功: `CI✓`
+    /// - 失敗: `CI✗`
+    /// - キャンセル: `CI○`
+    /// - その他: `CI?`
+    pub fn status_label(&self) -> &'static str {
+        match self.status {
+            CiRunStatus::Queued | CiRunStatus::InProgress => "CI⟳",
+            CiRunStatus::Completed => match self.conclusion {
+                Some(CiConclusion::Success) | Some(CiConclusion::Skipped) => "CI✓",
+                Some(CiConclusion::Failure) => "CI✗",
+                Some(CiConclusion::Cancelled) => "CI○",
+                _ => "CI?",
+            },
+        }
+    }
+}
+
 /// `exec` リクエストで使う待機条件
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/server/src/ipc.rs
+++ b/crates/server/src/ipc.rs
@@ -193,7 +193,7 @@ fn should_forward_message(msg: &ServerMessage, subscriptions: &HashSet<PaneId>) 
     }
 
     match msg {
-        ServerMessage::ExecResult { .. } => true,
+        ServerMessage::ExecResult { .. } | ServerMessage::CiStatus { .. } => true,
         ServerMessage::Output { pane, .. }
         | ServerMessage::TitleChanged { pane, .. }
         | ServerMessage::Notification { pane, .. }

--- a/crates/server/src/session/handlers/mod.rs
+++ b/crates/server/src/session/handlers/mod.rs
@@ -68,6 +68,9 @@ impl Server {
             ClientMessage::QueryAllPaneProcesses => self.handle_query_all_pane_processes().await,
             // Handshake は IPC 層で処理済みのため、ここには到達しない
             ClientMessage::Handshake { .. } => Ok(()),
+            // QueryCiStatus は app.rs の CI ポーラーが処理する（broadcast 経由）
+            // サーバー側では何もしない
+            ClientMessage::QueryCiStatus => Ok(()),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -60,6 +60,7 @@ use crate::app::{
     },
     layout_restore::load_initial_layout,
 };
+use crate::ci::run_ci_poller;
 use crate::config::{parse_hex_color, AppConfig, AppearanceConfig};
 
 /// `AppearanceConfig` から `Theme` を構築する
@@ -183,6 +184,7 @@ pub async fn run(
 
     let hooks = app_config.hooks;
     let theme = build_theme(&app_config.appearance);
+    let ci_ipc_tx = ipc_out_tx.clone();
     let bridge_rx = spawn_bridge_fanout(server_rx, ipc_out_tx);
     let state_sync_tx = client_tx.clone();
     spawn_server_bridge(
@@ -218,6 +220,12 @@ pub async fn run(
                 tokio::time::sleep(tokio::time::Duration::from_secs(interval_secs)).await;
             }
         });
+    }
+
+    // ── CI ステータスポーラー ─────────────────────────────────────────────
+    {
+        let ci_state = Arc::clone(&pane_store.lock().unwrap().ci_status);
+        tokio::spawn(run_ci_poller(app_config.ci, ci_state, ci_ipc_tx));
     }
 
     // ── Win32 ウィンドウ（spawn_blocking でメッセージループ実行）────────

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -1,0 +1,168 @@
+//! GitHub Actions CI ステータスポーラー
+//!
+//! `config.toml` の `[ci]` セクションに `repo = "owner/repo"` が設定されているとき、
+//! バックグラウンドで GitHub Actions API をポーリングして最新ランの状態を取得する。
+//!
+//! ## 設計上の分離
+//!
+//! - **取得側**: [`run_ci_poller`] がバックグラウンド tokio タスクとして動作し、
+//!   `Arc<std::sync::Mutex<Option<CiRunInfo>>>` に結果を書き込む。
+//! - **表示側**: Win32 スレッドからその Arc を読み込み、ステータスバーに描画する。
+//! - **IPC 配信**: ポーラーは更新のたびに `mpsc::Sender<ServerMessage>` 経由で
+//!   `ServerMessage::CiStatus` をブロードキャストする。
+
+use anyhow::Result;
+use serde::Deserialize;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+use tracing::{debug, error, info, warn};
+use yatamux_protocol::{CiConclusion, CiRunInfo, CiRunStatus, ServerMessage};
+
+use crate::config::CiConfig;
+
+/// GitHub API の workflow_run オブジェクト（必要フィールドのみ）
+#[derive(Debug, Deserialize)]
+struct ApiWorkflowRun {
+    name: String,
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    head_branch: Option<String>,
+    head_sha: String,
+    html_url: String,
+    updated_at: String,
+}
+
+/// GitHub API のレスポンス（`GET /repos/{owner}/{repo}/actions/runs`）
+#[derive(Debug, Deserialize)]
+struct ApiRunsResponse {
+    workflow_runs: Vec<ApiWorkflowRun>,
+}
+
+fn parse_status(status: &str) -> CiRunStatus {
+    match status {
+        "queued" | "waiting" | "pending" => CiRunStatus::Queued,
+        "in_progress" => CiRunStatus::InProgress,
+        _ => CiRunStatus::Completed,
+    }
+}
+
+fn parse_conclusion(conclusion: Option<&str>) -> Option<CiConclusion> {
+    match conclusion? {
+        "success" => Some(CiConclusion::Success),
+        "failure" => Some(CiConclusion::Failure),
+        "cancelled" => Some(CiConclusion::Cancelled),
+        "skipped" => Some(CiConclusion::Skipped),
+        _ => Some(CiConclusion::Unknown),
+    }
+}
+
+/// GitHub Actions API から最新 run を取得する
+async fn fetch_latest_run(
+    client: &reqwest::Client,
+    repo: &str,
+    branch: Option<&str>,
+) -> Result<Option<CiRunInfo>> {
+    let mut url = format!(
+        "https://api.github.com/repos/{}/actions/runs?per_page=1&exclude_pull_requests=true",
+        repo
+    );
+    if let Some(b) = branch {
+        url.push_str(&format!("&branch={}", b));
+    }
+
+    debug!("CI: polling {}", url);
+    let resp = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<ApiRunsResponse>()
+        .await?;
+
+    let Some(run) = resp.workflow_runs.into_iter().next() else {
+        return Ok(None);
+    };
+
+    Ok(Some(CiRunInfo {
+        repo: repo.to_string(),
+        name: run.name,
+        status: parse_status(&run.status),
+        conclusion: parse_conclusion(run.conclusion.as_deref()),
+        branch: run.head_branch,
+        head_sha: Some(run.head_sha.chars().take(7).collect()),
+        html_url: Some(run.html_url),
+        updated_at: Some(run.updated_at),
+    }))
+}
+
+/// CI ポーラーのバックグラウンドタスクを起動する
+///
+/// - `ci_state`: 取得結果を保持する共有 Arc（Win32 スレッドから参照）
+/// - `broadcast_tx`: 更新時に `CiStatus` をブロードキャストするチャネル
+///
+/// `config.repo` が `None` の場合は何もしない。
+pub async fn run_ci_poller(
+    config: CiConfig,
+    ci_state: Arc<Mutex<Option<CiRunInfo>>>,
+    broadcast_tx: mpsc::Sender<ServerMessage>,
+) {
+    let Some(repo) = config.repo else {
+        debug!("CI: no repo configured; poller disabled");
+        return;
+    };
+
+    let interval = Duration::from_secs(config.poll_interval_secs.max(10));
+    info!(
+        "CI: starting poller for {} (interval: {}s)",
+        repo, config.poll_interval_secs
+    );
+
+    let mut builder =
+        reqwest::Client::builder().user_agent(format!("yatamux/{}", env!("CARGO_PKG_VERSION")));
+    if let Some(token) = &config.token {
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(val) = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
+            headers.insert(reqwest::header::AUTHORIZATION, val);
+        }
+        builder = builder.default_headers(headers);
+    }
+
+    let client = match builder.build() {
+        Ok(c) => c,
+        Err(e) => {
+            error!("CI: failed to build HTTP client: {}", e);
+            return;
+        }
+    };
+
+    loop {
+        match fetch_latest_run(&client, &repo, config.branch.as_deref()).await {
+            Ok(new_info) => {
+                let changed = {
+                    let mut state = ci_state.lock().unwrap();
+                    if *state != new_info {
+                        *state = new_info.clone();
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if changed {
+                    let msg = ServerMessage::CiStatus { info: new_info };
+                    if broadcast_tx.send(msg).await.is_err() {
+                        info!("CI: broadcast channel closed; stopping poller");
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("CI: failed to fetch status for {}: {:#}", repo, e);
+            }
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,9 @@ pub struct AppConfig {
     /// ステータスバー設定
     #[serde(default)]
     pub status_bar: StatusBarConfig,
+    /// CI ステータス監視設定
+    #[serde(default)]
+    pub ci: CiConfig,
 }
 
 /// ステータスバー設定
@@ -117,6 +120,38 @@ pub fn parse_hex_color(s: &str) -> Option<(u8, u8, u8)> {
         Some((r, g, b))
     } else {
         None
+    }
+}
+
+/// CI ステータス監視設定
+///
+/// ```toml
+/// [ci]
+/// # 監視するリポジトリ（owner/repo 形式）
+/// repo = "raiga0310/yatamux"
+/// # GitHub Personal Access Token（省略時: 未認証、60 req/h の制限あり）
+/// # token = "ghp_xxxx"
+/// # ポーリング間隔（秒、デフォルト: 60）
+/// poll_interval_secs = 60
+/// # 監視するブランチ（省略時: デフォルトブランチの最新 run）
+/// # branch = "main"
+/// ```
+#[derive(Debug, Default, Deserialize)]
+pub struct CiConfig {
+    /// 監視リポジトリ（`"owner/repo"` 形式、省略時は CI 監視無効）
+    pub repo: Option<String>,
+    /// GitHub Personal Access Token（省略時: 未認証）
+    pub token: Option<String>,
+    /// ポーリング間隔（秒、デフォルト: 60）
+    #[serde(default = "CiConfig::default_poll_interval")]
+    pub poll_interval_secs: u64,
+    /// 監視するブランチ（省略時: デフォルトブランチの最新 run）
+    pub branch: Option<String>,
+}
+
+impl CiConfig {
+    fn default_poll_interval() -> u64 {
+        60
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ fn attach_parent_console() {
 }
 
 mod app;
+mod ci;
 mod cli;
 mod config;
 mod layout_config;


### PR DESCRIPTION
## 概要

- `config.toml` の `[ci]` セクションで GitHub リポジトリを設定すると、バックグラウンドポーラーが GitHub Actions API をポーリングしてステータスバーに CI ステータスを表示する
- ステータス表示: `CI✓`（成功）/ `CI✗`（失敗）/ `CI⟳`（実行中/待機中）/ `CI○`（キャンセル）
- IPC クライアント（Claude Code など）にも `ServerMessage::CiStatus` としてブロードキャストされるため、`gh run watch` は不要になる

## 設定例

```toml
[ci]
repo = "owner/repo"
token = "ghp_xxxx"          # optional: private repo 用
poll_interval_secs = 60     # default: 60 (最小 10)
branch = "main"             # optional: ブランチフィルター
```

## 変更内容

### 新規ファイル
- `src/ci.rs` — GitHub Actions API ポーラー実装（`run_ci_poller()`）
  - `GET /repos/{owner}/{repo}/actions/runs?per_page=1` をポーリング
  - `Authorization: Bearer <token>` ヘッダー対応
  - 変化があったときのみ `ServerMessage::CiStatus` をブロードキャスト

### 既存ファイル変更
- `crates/protocol/src/types.rs` — `CiRunInfo`, `CiRunStatus`, `CiConclusion` 型追加（`status_label()` メソッド含む）
- `crates/protocol/src/message.rs` — `ClientMessage::QueryCiStatus` / `ServerMessage::CiStatus { info }` 追加
- `crates/protocol/src/lib.rs` — CI 型を `pub use` に追加
- `src/config.rs` — `CiConfig` 追加（`AppConfig.ci` フィールド）
- `src/app.rs` — CI ポーラータスクの起動・配線
- `crates/client/src/layout/store.rs` — `PaneStore.ci_status: Arc<Mutex<Option<CiRunInfo>>>` フィールド追加
- `crates/client/src/window/mod.rs` — ステータスバー右側に CI ラベル表示（`format_status_bar_right_text` 更新）
- `crates/client/src/window/win32/wndproc.rs` — WM_TIMER で CI ステータスをキャッシュに同期
- `crates/server/src/ipc.rs` — `CiStatus` を `should_forward_message` で常時転送に追加
- `crates/server/src/session/handlers/mod.rs` — `QueryCiStatus` を no-op で処理（サーバー側では不要）

## 設計上の分離

- **取得側**: `run_ci_poller` がバックグラウンド tokio タスクとして動作し、`Arc<Mutex<Option<CiRunInfo>>>` に結果を書き込む
- **表示側**: Win32 スレッドが WM_TIMER でキャッシュを更新し、WM_PAINT でステータスバーに描画
- **IPC 配信**: 変化のあったときのみ `ServerMessage::CiStatus` をブロードキャスト

## テスト

- `test_format_status_bar_right_text_shows_ci_label` 追加（`window/mod.rs`）
- `cargo clippy -- -D warnings` / `cargo test` / `cargo fmt --check` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)