### PR TITLE
fix(update): use YATAMUX_SESSION env as default session (B-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,7 +2335,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yatamux"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "yatamux-client"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "serde",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "yatamux-protocol"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "serde",
  "serde_json",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "yatamux-renderer"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "yatamux-server"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "yatamux-terminal"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.32"
+version = "0.1.33"
 edition = "2021"
 description = "CJK-aware terminal multiplexer for Windows"
 repository = "https://github.com/raiga0310/yatamux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sha2 = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 # CLI argument parsing
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 
 # Config
 toml = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,10 @@ pub const DEFAULT_SESSION: &str = "default";
 #[command(name = "yatamux", version, about)]
 struct Cli {
     /// 対象セッション名（IPC パイプ名のサフィックス）
-    #[arg(long, default_value = DEFAULT_SESSION, global = true, hide = true)]
+    ///
+    /// 省略時は `YATAMUX_SESSION` 環境変数を参照し、それも未設定なら "default" を使用する。
+    /// ペイン内から CLI サブコマンドを実行する際に自動で正しいセッションへ接続できる。
+    #[arg(long, env = "YATAMUX_SESSION", default_value = DEFAULT_SESSION, global = true, hide = true)]
     session: String,
 
     /// 起動時に適用するレイアウト名（%APPDATA%\yatamux\layouts\<NAME>.toml）

--- a/tests/update_helper_probe.rs
+++ b/tests/update_helper_probe.rs
@@ -33,6 +33,10 @@ fn build_command(exe: &Path, appdata: &Path, session: &str) -> Command {
         .arg("--session")
         .arg(session)
         .env("APPDATA", appdata)
+        // ペイン内でテストを実行しても YATAMUX=1 を引き継がないようにする。
+        // is_running_inside_yatamux() が true になると update のフォールバックパスが
+        // 封じられてテストが誤って失敗するため、ここで明示的に除去する。
+        .env_remove("YATAMUX")
         .creation_flags(CREATE_NO_WINDOW);
     command
 }


### PR DESCRIPTION
## 問題

ペイン内から `yatamux update` を実行すると exit code 1 で即終了する（B-1）。

**根本原因 1**: `--session` 引数がデフォルト `"default"` を使うため、カスタムセッション名（例: `--session work`）で起動した yatamux ペイン内から update すると `\.\pipe\yatamux-default` に接続しようとして失敗する。

**根本原因 2**: `update_helper_probe` テストをペイン内で実行すると `YATAMUX=1` を引き継ぎ、`is_running_inside_yatamux()` が true になってフォールバックパスが封じられてテストが誤って失敗する。

## 修正内容

- `Cargo.toml`: clap に `env` フィーチャーを追加
- `src/main.rs`: `--session` 引数に `env = "YATAMUX_SESSION"` を追加
  - 優先度: 明示的な `--session` 引数 > `YATAMUX_SESSION` 環境変数 > デフォルト `"default"`
  - ペイン内でどの CLI サブコマンドを実行しても自動で正しいセッション名が使われるようになる
- `tests/update_helper_probe.rs`: `build_command` に `.env_remove("YATAMUX")` を追加
  - テストをペイン内で実行しても `is_running_inside_yatamux()` が誤って true にならない

## テスト

```
test apply_update_helper_mode_writes_probe_and_exits ... ok
test update_fallback_spawns_helper_and_returns ... ok   ← 修正前は FAILED
test update_gui_path_spawns_detached_helper_and_returns ... ok
test update_gui_path_relaunches_with_same_session_and_appdata ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)