### PR TITLE
fix(render): resize_all_panes on layout_changed to fix split-pane width overflow (F-5)

### DIFF
--- a/crates/client/src/window/win32/wndproc.rs
+++ b/crates/client/src/window/win32/wndproc.rs
@@ -291,11 +291,17 @@ pub(super) unsafe fn handle_wm_timer(
 
         // レイアウト変更（split / close）後はバックバッファを破棄して全画面再描画する。
         // これにより旧ペイン領域の残像（端数ピクセルを含む）が消える（F-5）。
+        // さらに resize_all_panes を呼び直すことで、分割後の Grid cols を
+        // compute_rects() と同じピクセル精度で再計算する（F-5 突き抜け修正）。
         {
             let mut store = state.panes.lock().unwrap();
             if store.layout_changed {
                 store.layout_changed = false;
                 drop(store);
+                let cr = state.content_rect.get();
+                if cr.w > 0 && cr.h > 0 {
+                    state.resize_all_panes(cr.w, cr.h);
+                }
                 state.content_bb.set(None);
             }
         }


### PR DESCRIPTION
## 概要

ペイン分割後に旧ペインの描画が境界を突き抜ける問題を修正。

## 原因

`WM_TIMER` が `layout_changed` を検出した際、バックバッファをクリアするだけで `resize_all_panes()` を呼んでいなかった。

- `bridge.rs` は `g.cols() / 2`（セパレーター 1px を無視した整数除算）で親 Grid を縮小する
- `WM_PAINT` の `compute_rects()` はピクセル精度で幅を計算する
  - 例: 172 cols の親を縦分割 → bridge.rs は 86 cols に縮小、compute_rects() は 85 cols を割り当て
- この 1 列のずれが、Grid の 86 列目を境界外に描画させていた

`resize_all_panes()` は `WM_SIZE` からしか呼ばれないため、ウィンドウサイズが変わらない限り分割後の Grid cols が補正されなかった。

## 修正

`wndproc.rs` の `layout_changed` 検出ブロックに `resize_all_panes()` 呼び出しを追加。

```rust
if store.layout_changed {
    store.layout_changed = false;
    drop(store);
    let cr = state.content_rect.get();  // WM_SIZE 時に保存済み
    if cr.w > 0 && cr.h > 0 {
        state.resize_all_panes(cr.w, cr.h);  // ← 追加
    }
    state.content_bb.set(None);
}
```

`compute_rects()` と同じピクセル精度で全ペインの Grid cols が再計算されるため、分割後も描画が境界内に収まる。

## 影響範囲

- `crates/client/src/window/win32/wndproc.rs` のみ変更
- バックバッファクリア前に `resize_all_panes` を実行するため、次の `WM_PAINT` では正確なサイズで描画される
- ペインクローズ時（`layout_changed` が立つ別ケース）でも無害（クローズ済みペインはレイアウトツリーから除外済みのため再計算対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)