### PR TITLE
ci: fix bump cascade caused by merge commits from bump branches

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,9 +18,13 @@ jobs:
   bump:
     name: Bump patch version
     runs-on: ubuntu-latest
-    # バージョンバンプ / docs / ci のコミット自身はスキップして無限ループを防止
+    # バンプ PR のマージを検出してカスケードを防止。
+    # squash merge → "chore: bump version to X.X.X" で始まる
+    # merge commit → "Merge pull request #N from .../chore/bump-version-..." を含む
+    # どちらも除外しないとバンプ PR マージ → 新バンプ起動の無限ループになる。
     if: |
       !startsWith(github.event.head_commit.message, 'chore: bump version') &&
+      !contains(github.event.head_commit.message, 'chore/bump-version') &&
       !startsWith(github.event.head_commit.message, 'docs:') &&
       !startsWith(github.event.head_commit.message, 'ci:')
     outputs:


### PR DESCRIPTION
## 原因

bump PR がマージされると HEAD commit のメッセージは以下の形式になる。

```
Merge pull request #144 from raiga0310/chore/bump-version-0.1.45
```

既存の `if:` 条件は `startsWith('chore: bump version')` のみチェックしており、この形式にマッチしなかった。そのため bump PR マージのたびに新しい bump ジョブが起動し、カスケードが発生していた（v0.1.39 〜 v0.1.47 が連鎖生成された）。

前回追加した `concurrency: cancel-in-progress: false` はジョブを直列化するだけで、カスケード自体は止まっていなかった。

## 修正

```yaml
!contains(github.event.head_commit.message, 'chore/bump-version')
```

を追加。squash merge・merge commit どちらの形式でも bump PR マージを検出してスキップする。

| マージ方法 | HEAD commit message | 検出 |
|-----------|-------------------|------|
| squash | `chore: bump version to 0.1.45 (#144)` | `startsWith` で検出済み |
| merge commit | `Merge pull request #144 from .../chore/bump-version-0.1.45` | **今回追加** |

## マージ後にやること（手動操作が必要）

- PR #148 (`chore/bump-version-0.1.46`) をクローズ・ブランチ削除
- PR #149 (`chore/bump-version-0.1.47`) をクローズ・ブランチ削除
- タグ `v0.1.46`・`v0.1.47` を削除（リリースが作られていれば削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)