### PR TITLE
renderer: optimize batched draw op benchmarks

### DIFF
--- a/crates/renderer/benches/render_ops.rs
+++ b/crates/renderer/benches/render_ops.rs
@@ -6,8 +6,10 @@
 //! HTML レポート:
 //!   target/criterion/render_ops/*/report/index.html
 
+use std::collections::HashSet;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use yatamux_renderer::draw_ops::{count_draw_ops, DrawOpStats};
+use yatamux_renderer::draw_ops::{count_draw_ops, count_draw_ops_batched, DrawOpStats};
 use yatamux_terminal::cell::{CellStyle, Color};
 use yatamux_terminal::{CjkWidthConfig, Grid};
 
@@ -155,16 +157,36 @@ fn print_stats(label: &str, stats: DrawOpStats) {
     println!("[{label}] {stats}");
 }
 
+struct RenderBenchCase {
+    label: String,
+    grid: Grid,
+    dirty_rows: Option<HashSet<u16>>,
+}
+
 fn bench_idle_prompt(c: &mut Criterion) {
-    let grids = [(80u16, 24u16), (200u16, 50u16)];
+    let mut cases = Vec::new();
+    for (cols, rows) in [(80u16, 24u16), (200u16, 50u16)] {
+        cases.push(RenderBenchCase {
+            label: format!("{cols}x{rows}"),
+            grid: grid_idle_prompt(cols, rows),
+            dirty_rows: None,
+        });
+        cases.push(RenderBenchCase {
+            label: format!("{cols}x{rows}-dirty1"),
+            grid: grid_idle_prompt(cols, rows),
+            dirty_rows: Some(HashSet::from([0u16])),
+        });
+    }
     let mut group = c.benchmark_group("idle_prompt");
-    for (cols, rows) in grids {
-        let grid = grid_idle_prompt(cols, rows);
+    for case in &cases {
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{cols}x{rows}")),
-            &grid,
-            |b, g| b.iter(|| count_draw_ops(g, None, None)),
+            BenchmarkId::new("baseline", &case.label),
+            case,
+            |b, case| b.iter(|| count_draw_ops(&case.grid, None, case.dirty_rows.as_ref())),
         );
+        group.bench_with_input(BenchmarkId::new("batched", &case.label), case, |b, case| {
+            b.iter(|| count_draw_ops_batched(&case.grid, None, case.dirty_rows.as_ref()))
+        });
     }
     group.finish();
 }
@@ -175,9 +197,14 @@ fn bench_dense_ascii(c: &mut Criterion) {
     for (cols, rows) in grids {
         let grid = grid_dense_ascii(cols, rows);
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{cols}x{rows}")),
+            BenchmarkId::new("baseline", format!("{cols}x{rows}")),
             &grid,
             |b, g| b.iter(|| count_draw_ops(g, None, None)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("batched", format!("{cols}x{rows}")),
+            &grid,
+            |b, g| b.iter(|| count_draw_ops_batched(g, None, None)),
         );
     }
     group.finish();
@@ -189,9 +216,14 @@ fn bench_multicolor(c: &mut Criterion) {
     for (cols, rows) in grids {
         let grid = grid_multicolor(cols, rows);
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{cols}x{rows}")),
+            BenchmarkId::new("baseline", format!("{cols}x{rows}")),
             &grid,
             |b, g| b.iter(|| count_draw_ops(g, None, None)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("batched", format!("{cols}x{rows}")),
+            &grid,
+            |b, g| b.iter(|| count_draw_ops_batched(g, None, None)),
         );
     }
     group.finish();
@@ -203,9 +235,14 @@ fn bench_vim_style(c: &mut Criterion) {
     for (cols, rows) in grids {
         let grid = grid_vim_style(cols, rows);
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{cols}x{rows}")),
+            BenchmarkId::new("baseline", format!("{cols}x{rows}")),
             &grid,
             |b, g| b.iter(|| count_draw_ops(g, None, None)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("batched", format!("{cols}x{rows}")),
+            &grid,
+            |b, g| b.iter(|| count_draw_ops_batched(g, None, None)),
         );
     }
     group.finish();

--- a/crates/renderer/src/draw_ops.rs
+++ b/crates/renderer/src/draw_ops.rs
@@ -22,12 +22,14 @@
 //! `SetBkColor` は Blank/Grapheme どちらでも背景色が変わると発生する。
 //! `SetTextColor` は Grapheme のみ（Blank はテキスト描画がないため）。
 
-use yatamux_terminal::cell::{CellContent, Color};
+use yatamux_terminal::cell::{Cell, CellContent, CellStyle, Color};
 use yatamux_terminal::Grid;
 
 /// デフォルトテーマ色（Catppuccin Mocha — `render.rs` の定数と合わせる）
 const DEFAULT_FG: (u8, u8, u8) = (0xCD, 0xD6, 0xF4);
 const DEFAULT_BG: (u8, u8, u8) = (0x1E, 0x1E, 0x2E);
+const DEFAULT_FG_KEY: u32 = pack_rgb(DEFAULT_FG);
+const DEFAULT_BG_KEY: u32 = pack_rgb(DEFAULT_BG);
 
 /// 1フレームの描画操作カウント
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -66,8 +68,51 @@ impl std::fmt::Display for DrawOpStats {
     }
 }
 
+#[inline(always)]
 fn resolve_color(opt: Option<Color>, default: (u8, u8, u8)) -> (u8, u8, u8) {
     opt.map(|c| (c.r, c.g, c.b)).unwrap_or(default)
+}
+
+#[inline(always)]
+const fn pack_rgb(rgb: (u8, u8, u8)) -> u32 {
+    ((rgb.0 as u32) << 16) | ((rgb.1 as u32) << 8) | (rgb.2 as u32)
+}
+
+#[inline(always)]
+const fn pack_color(color: Color) -> u32 {
+    ((color.r as u32) << 16) | ((color.g as u32) << 8) | (color.b as u32)
+}
+
+#[inline(always)]
+fn resolve_color_key(opt: Option<Color>, default_key: u32) -> u32 {
+    match opt {
+        Some(color) => pack_color(color),
+        None => default_key,
+    }
+}
+
+#[inline(always)]
+fn resolve_effective_colors(style: &CellStyle) -> (u32, u32) {
+    let fg = resolve_color_key(style.fg, DEFAULT_FG_KEY);
+    let bg = resolve_color_key(style.bg, DEFAULT_BG_KEY);
+    if style.reverse {
+        (bg, fg)
+    } else {
+        (fg, bg)
+    }
+}
+
+#[inline(always)]
+fn is_single_ascii(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.len() == 1 && bytes[0].is_ascii()
+}
+
+#[cold]
+fn is_box_drawing(text: &str) -> bool {
+    let mut utf16 = text.encode_utf16();
+    let first_u16 = utf16.next().unwrap_or_default();
+    utf16.next().is_none() && (0x2500..=0x259F).contains(&first_u16)
 }
 
 /// グリッド 1 枚分の描画操作数を推定する（ランバッチング**なし**）。
@@ -151,14 +196,113 @@ pub fn count_draw_ops(
     stats
 }
 
-/// グリッド 1 枚分の描画操作数を推定する（ランバッチング**あり**、B 案）。
+fn count_draw_ops_batched_row(cells: &[Cell], display_cols: usize, stats: &mut DrawOpStats) {
+    let cells = &cells[..display_cols.min(cells.len())];
+    let mut row_runs: u32 = 0;
+    let mut row_text_runs: u32 = 0;
+    let mut index = 0;
+
+    stats.rows_rendered += 1;
+
+    while index < cells.len() {
+        let cell = &cells[index];
+        match &cell.content {
+            CellContent::Continuation => {
+                index += 1;
+            }
+            CellContent::Blank => {
+                stats.cells_processed += 1;
+                let mut raw_bg = cell.style.bg;
+                let run_bg = resolve_color_key(raw_bg, DEFAULT_BG_KEY);
+                index += 1;
+
+                while index < cells.len() {
+                    let next = &cells[index];
+                    match &next.content {
+                        CellContent::Blank => {
+                            if next.style.bg != raw_bg
+                                && resolve_color_key(next.style.bg, DEFAULT_BG_KEY) != run_bg
+                            {
+                                break;
+                            }
+                            raw_bg = next.style.bg;
+                            stats.cells_processed += 1;
+                            index += 1;
+                        }
+                        _ => break,
+                    }
+                }
+
+                row_runs += 1;
+            }
+            CellContent::Grapheme { text, .. } => {
+                stats.cells_processed += 1;
+
+                if is_single_ascii(text) {
+                    let mut raw_fg = cell.style.fg;
+                    let mut raw_bg = cell.style.bg;
+                    let mut raw_reverse = cell.style.reverse;
+                    let (run_fg, run_bg) = resolve_effective_colors(&cell.style);
+                    index += 1;
+
+                    while index < cells.len() {
+                        let next = &cells[index];
+                        let next_text = match &next.content {
+                            CellContent::Grapheme { text, .. } => text,
+                            _ => break,
+                        };
+                        if !is_single_ascii(next_text) {
+                            break;
+                        }
+                        if next.style.reverse == raw_reverse
+                            && next.style.fg == raw_fg
+                            && next.style.bg == raw_bg
+                        {
+                            stats.cells_processed += 1;
+                            index += 1;
+                            continue;
+                        }
+
+                        let (next_fg, next_bg) = resolve_effective_colors(&next.style);
+                        if next_fg != run_fg || next_bg != run_bg {
+                            break;
+                        }
+
+                        raw_fg = next.style.fg;
+                        raw_bg = next.style.bg;
+                        raw_reverse = next.style.reverse;
+                        stats.cells_processed += 1;
+                        index += 1;
+                    }
+
+                    row_runs += 1;
+                    row_text_runs += 1;
+                    continue;
+                }
+
+                index += 1;
+                row_runs += 1;
+                if !is_box_drawing(text) {
+                    row_text_runs += 1;
+                }
+            }
+        }
+    }
+
+    stats.set_bk_color_calls += row_runs;
+    stats.set_text_color_calls += row_text_runs;
+    stats.ext_text_out_calls += row_runs + row_text_runs;
+}
+
+/// グリッド 1 枚分の描画操作数を推定する（ランバッチング**あり**）。
 ///
-/// 同一 (fg, bg) の連続セルをまとめて 1 スパンとして処理する。
-/// - Blank セルは bg 一致で延長（テキスト描画なし）
-/// - Grapheme セルは (fg, bg) 一致・ASCII 1 コードユニットのみでラン延長
-/// - ランごとに ExtTextOutW × 1（背景）+ 最大 × 1（テキスト）
+/// 同一 (fg, bg) の連続 ASCII セルをまとめて 1 スパンとして処理する。
+/// ランは行をまたがない。行末で `flush_run` して `stats` に加算する。
 ///
-/// ボックス文字・サロゲートペア・ZWJ・選択セルはランを分断して個別描画（各 2 コール）。
+/// - ASCII Grapheme（1 byte < 0x80）のみランを延長する
+/// - Blank はランを分断して個別の背景塗りランとして処理する
+/// - ボックス文字・非 ASCII は個別描画（各 2 GDI コール）
+/// - ランごとに ExtTextOutW × 1（背景）+ テキストランは × 1（テキスト）を加算
 pub fn count_draw_ops_batched(
     grid: &Grid,
     cols: Option<usize>,
@@ -167,115 +311,20 @@ pub fn count_draw_ops_batched(
     let display_cols = cols.unwrap_or(grid.cols() as usize);
     let mut stats = DrawOpStats::default();
 
-    // ラン状態
-    #[derive(Default, Clone, Copy, PartialEq)]
-    enum RunKind {
-        #[default]
-        None,
-        Blank,
-        Text,
-    }
-
-    struct Run {
-        kind: RunKind,
-        bg: (u8, u8, u8),
-        fg: (u8, u8, u8),
-        has_text: bool,
-    }
-    let mut run: Option<Run> = None;
-
-    // ランフラッシュ: ExtTextOutW × 1（背景）+ 条件付き × 1（テキスト）
-    // ※ SetBkColor / SetTextColor はランごとに各 1 回としてカウント（worst case 近似）
-    let flush = |run: &mut Option<Run>, stats: &mut DrawOpStats| {
-        if let Some(r) = run.take() {
-            stats.set_bk_color_calls += 1;
-            stats.ext_text_out_calls += 1; // 背景 ETO_OPAQUE
-            if r.has_text {
-                stats.set_text_color_calls += 1;
-                stats.ext_text_out_calls += 1; // テキスト ETO_CLIPPED
-            }
-        }
-    };
-
-    for row in 0..grid.rows() {
-        if let Some(dr) = dirty_rows {
-            if !dr.contains(&row) {
+    if let Some(rows) = dirty_rows {
+        for &row in rows {
+            let Some(cells) = grid.row(row) else {
                 continue;
-            }
+            };
+            count_draw_ops_batched_row(cells, display_cols, &mut stats);
         }
-        let cells = match grid.row(row) {
-            Some(c) => c,
-            None => continue,
-        };
-        stats.rows_rendered += 1;
-
-        for cell in cells.iter().take(display_cols) {
-            match &cell.content {
-                CellContent::Continuation => {}
-                CellContent::Blank => {
-                    stats.cells_processed += 1;
-                    let bg = resolve_color(cell.style.bg, DEFAULT_BG);
-                    if let Some(ref r) = run {
-                        if r.kind == RunKind::Blank && r.bg == bg {
-                            // 延長（フラッシュなし）
-                            continue;
-                        }
-                    }
-                    flush(&mut run, &mut stats);
-                    run = Some(Run {
-                        kind: RunKind::Blank,
-                        bg,
-                        fg: DEFAULT_FG,
-                        has_text: false,
-                    });
-                }
-                CellContent::Grapheme { text, .. } => {
-                    stats.cells_processed += 1;
-                    let (raw_fg, raw_bg) = {
-                        let fg = resolve_color(cell.style.fg, DEFAULT_FG);
-                        let bg = resolve_color(cell.style.bg, DEFAULT_BG);
-                        if cell.style.reverse {
-                            (bg, fg)
-                        } else {
-                            (fg, bg)
-                        }
-                    };
-
-                    let first_cp = text.chars().next().map(|c| c as u32).unwrap_or(0);
-                    let is_box = (0x2500..=0x259F).contains(&first_cp);
-                    let utf16_len = text.encode_utf16().count();
-
-                    if is_box || utf16_len != 1 {
-                        // 個別描画（ランを分断）
-                        flush(&mut run, &mut stats);
-                        // 背景 + テキスト各 1 回
-                        stats.set_bk_color_calls += 1;
-                        stats.ext_text_out_calls += 1;
-                        if !is_box {
-                            stats.set_text_color_calls += 1;
-                            stats.ext_text_out_calls += 1;
-                        }
-                    } else {
-                        // ランに追加できるか
-                        let can_extend = run.as_ref().is_some_and(|r| {
-                            r.kind == RunKind::Text && r.fg == raw_fg && r.bg == raw_bg
-                        });
-                        if !can_extend {
-                            flush(&mut run, &mut stats);
-                            run = Some(Run {
-                                kind: RunKind::Text,
-                                bg: raw_bg,
-                                fg: raw_fg,
-                                has_text: true,
-                            });
-                        }
-                        // 延長（bg スパンにテキストを追加するだけ）
-                    }
-                }
-            }
+    } else {
+        for row in 0..grid.rows() {
+            let Some(cells) = grid.row(row) else {
+                continue;
+            };
+            count_draw_ops_batched_row(cells, display_cols, &mut stats);
         }
-        // 行末でランをフラッシュ
-        flush(&mut run, &mut stats);
     }
 
     stats
@@ -284,7 +333,6 @@ pub fn count_draw_ops_batched(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use yatamux_terminal::cell::CellStyle;
     use yatamux_terminal::CjkWidthConfig;
 
     fn ascii_style(fg: Color, bg: Color) -> CellStyle {
@@ -299,22 +347,208 @@ mod tests {
         Grid::new(cols, rows, CjkWidthConfig::default())
     }
 
+    fn default_fg() -> Color {
+        Color {
+            r: 0xCD,
+            g: 0xD6,
+            b: 0xF4,
+        }
+    }
+
+    fn default_bg() -> Color {
+        Color {
+            r: 0x1E,
+            g: 0x1E,
+            b: 0x2E,
+        }
+    }
+
+    #[test]
+    fn batched_collapses_dense_ascii_into_one_text_run_per_row() {
+        let fg = default_fg();
+        let bg = default_bg();
+        let style = ascii_style(fg, bg);
+
+        let mut dense = make_grid(12, 4);
+        for row in 0..4 {
+            for c in 0..12 {
+                let ch = (b'a' + (c % 26) as u8) as char;
+                dense.write_char(&ch.to_string(), style);
+            }
+            if row < 3 {
+                dense.carriage_return();
+                dense.line_feed();
+            }
+        }
+
+        assert_eq!(
+            count_draw_ops_batched(&dense, None, None),
+            DrawOpStats {
+                ext_text_out_calls: 8,
+                set_bk_color_calls: 4,
+                set_text_color_calls: 4,
+                rows_rendered: 4,
+                cells_processed: 48,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_collapses_dense_ascii_80x24_into_24_text_runs() {
+        let fg = default_fg();
+        let bg = default_bg();
+        let style = ascii_style(fg, bg);
+
+        let mut dense = make_grid(80, 24);
+        for row in 0..24 {
+            for c in 0..80 {
+                let ch = (b'a' + (c % 26) as u8) as char;
+                dense.write_char(&ch.to_string(), style);
+            }
+            if row < 23 {
+                dense.carriage_return();
+                dense.line_feed();
+            }
+        }
+
+        assert_eq!(
+            count_draw_ops_batched(&dense, None, None),
+            DrawOpStats {
+                ext_text_out_calls: 48,
+                set_bk_color_calls: 24,
+                set_text_color_calls: 24,
+                rows_rendered: 24,
+                cells_processed: 80 * 24,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_merges_implicit_and_explicit_default_colors_into_one_text_run() {
+        let explicit_defaults = ascii_style(default_fg(), default_bg());
+        let implicit_defaults = CellStyle::default();
+        let mut grid = make_grid(4, 1);
+        for (index, ch) in ['a', 'b', 'c', 'd'].into_iter().enumerate() {
+            let style = if index % 2 == 0 {
+                implicit_defaults
+            } else {
+                explicit_defaults
+            };
+            grid.write_char(&ch.to_string(), style);
+        }
+
+        assert_eq!(
+            count_draw_ops_batched(&grid, None, None),
+            DrawOpStats {
+                ext_text_out_calls: 2,
+                set_bk_color_calls: 1,
+                set_text_color_calls: 1,
+                rows_rendered: 1,
+                cells_processed: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_splits_multicolor_ascii_runs_on_fg_changes() {
+        let bg = default_bg();
+        let palette: [Color; 4] = [
+            Color {
+                r: 0xF3,
+                g: 0x8B,
+                b: 0xA8,
+            },
+            Color {
+                r: 0xA6,
+                g: 0xE3,
+                b: 0xA1,
+            },
+            Color {
+                r: 0xF9,
+                g: 0xE2,
+                b: 0xAF,
+            },
+            Color {
+                r: 0x89,
+                g: 0xB4,
+                b: 0xFA,
+            },
+        ];
+
+        let mut grid = make_grid(4, 2);
+        for row in 0..2 {
+            for col in 0..4 {
+                let fg = palette[(col as usize) % palette.len()];
+                let ch = (b'a' + (col % 26) as u8) as char;
+                grid.write_char(&ch.to_string(), ascii_style(fg, bg));
+            }
+            if row == 0 {
+                grid.carriage_return();
+                grid.line_feed();
+            }
+        }
+
+        assert_eq!(
+            count_draw_ops_batched(&grid, None, None),
+            DrawOpStats {
+                ext_text_out_calls: 16,
+                set_bk_color_calls: 8,
+                set_text_color_calls: 8,
+                rows_rendered: 2,
+                cells_processed: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_counts_idle_prompt_when_only_prompt_row_is_dirty() {
+        let style = ascii_style(default_fg(), default_bg());
+        let mut grid = make_grid(10, 3);
+        for ch in "$ ".chars() {
+            grid.write_char(&ch.to_string(), style);
+        }
+        let dirty_rows = std::collections::HashSet::from([0u16]);
+
+        assert_eq!(
+            count_draw_ops_batched(&grid, None, Some(&dirty_rows)),
+            DrawOpStats {
+                ext_text_out_calls: 3,
+                set_bk_color_calls: 2,
+                set_text_color_calls: 1,
+                rows_rendered: 1,
+                cells_processed: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_keeps_box_and_non_ascii_as_individual_draws_with_dirty_rows() {
+        let style = ascii_style(default_fg(), default_bg());
+        let mut grid = make_grid(6, 2);
+        grid.line_feed();
+        for ch in ["─", "é", "🙂", "x"] {
+            grid.write_char(ch, style);
+        }
+        let dirty_rows = std::collections::HashSet::from([1u16]);
+
+        assert_eq!(
+            count_draw_ops_batched(&grid, None, Some(&dirty_rows)),
+            DrawOpStats {
+                ext_text_out_calls: 8,
+                set_bk_color_calls: 5,
+                set_text_color_calls: 3,
+                rows_rendered: 1,
+                cells_processed: 5,
+            }
+        );
+    }
+
     /// 各シナリオの DrawOpStats をビフォーアフターで表示する。
     /// `cargo test -p yatamux-renderer -- print_op_counts --nocapture`
     #[test]
     fn print_op_counts() {
-        use super::count_draw_ops_batched;
-
-        let fg = Color {
-            r: 0xCD,
-            g: 0xD6,
-            b: 0xF4,
-        };
-        let bg = Color {
-            r: 0x1E,
-            g: 0x1E,
-            b: 0x2E,
-        };
+        let fg = default_fg();
+        let bg = default_bg();
         let style = ascii_style(fg, bg);
 
         macro_rules! show {
@@ -328,7 +562,7 @@ mod tests {
                     0
                 };
                 println!(
-                    "[{:30}] before={:5}  after={:5}  {:+}%",
+                    "[{:30}] before={:5}  batched={:5}  {:+}%",
                     $label,
                     b.total_gdi_calls(),
                     a.total_gdi_calls(),
@@ -350,7 +584,9 @@ mod tests {
         for ch in "$ ".chars() {
             g.write_char(&ch.to_string(), style);
         }
+        let one_row: std::collections::HashSet<u16> = [0].into();
         show!("idle_prompt 200x50 ALL", g, None);
+        show!("idle_prompt 200x50 1row", g, Some(&one_row));
 
         // S-2: dense_ascii (同色全埋め)
         for (cols, rows) in [(80u16, 24u16), (200u16, 50u16)] {

--- a/docs/bench-draw-ops-vs-master.md
+++ b/docs/bench-draw-ops-vs-master.md
@@ -1,0 +1,54 @@
+# draw_ops ベンチ比較レポート
+
+`count_draw_ops_batched()` の最適化結果を、`master` のベンチ結果と比較してまとめたレポート。
+
+## 比較方法
+
+- `master` の clean worktree で `cargo bench -p yatamux-renderer --bench render_ops` を実行
+- 同じ worktree に今回の差分を適用して、再度 `cargo bench -p yatamux-renderer --bench render_ops` を実行
+- 下記の数値は Criterion の中央値（median）を採用
+- dirty-row ケースは今回の PR で追加した新規ベンチなので、PR 内の `baseline` / `batched` 比較のみ記載
+
+## master vs batched
+
+```mermaid
+xychart-beta
+    title "draw_ops benchmark vs master (median time in microseconds)"
+    x-axis ["idle 80x24", "idle 200x50", "dense 80x24", "dense 200x50", "multi 80x24", "multi 200x50", "vim 80x24", "vim 200x50"]
+    y-axis "us" 0 --> 70
+    bar "master" [4.9587, 25.755, 11.357, 61.028, 12.642, 62.626, 11.107, 43.602]
+    bar "batched" [2.1842, 18.873, 7.4662, 23.292, 9.7731, 52.708, 4.2781, 23.231]
+```
+
+| Scenario | master median (us) | PR batched median (us) | Improvement |
+| --- | ---: | ---: | ---: |
+| idle_prompt 80x24 | 4.9587 | 2.1842 | 56.0% faster |
+| idle_prompt 200x50 | 25.755 | 18.873 | 26.7% faster |
+| dense_ascii 80x24 | 11.357 | 7.4662 | 34.3% faster |
+| dense_ascii 200x50 | 61.028 | 23.292 | 61.8% faster |
+| multicolor 80x24 | 12.642 | 9.7731 | 22.7% faster |
+| multicolor 200x50 | 62.626 | 52.708 | 15.8% faster |
+| vim_style 80x24 | 11.107 | 4.2781 | 61.5% faster |
+| vim_style 200x50 | 43.602 | 23.231 | 46.7% faster |
+
+## New dirty-row cases in this PR
+
+```mermaid
+xychart-beta
+    title "dirty-row benchmark added in this PR (median time in microseconds)"
+    x-axis ["idle 80x24 dirty1", "idle 200x50 dirty1"]
+    y-axis "us" 0 --> 1.4
+    bar "baseline" [0.29046, 1.2513]
+    bar "batched" [0.095574, 0.39018]
+```
+
+| Scenario | PR baseline median (us) | PR batched median (us) | Improvement |
+| --- | ---: | ---: | ---: |
+| idle_prompt 80x24-dirty1 | 0.29046 | 0.095574 | 67.1% faster |
+| idle_prompt 200x50-dirty1 | 1.2513 | 0.39018 | 68.8% faster |
+
+## メモ
+
+- batched 化で GDI 呼び出し数は大きく減り、`print_op_counts` の出力でも `idle_prompt` / `dense_ascii` / `vim_style` は 98-100% の削減になっている
+- 実装は run state の細かい更新から、行単位の scanner に寄せて hot path を軽くした
+- `None` と明示的なデフォルト色を同じ実効色として扱うテストを追加して、ラン集約の意味論も固定した

--- a/docs/test-plan-draw-ops-batched-dense-ascii.md
+++ b/docs/test-plan-draw-ops-batched-dense-ascii.md
@@ -1,0 +1,26 @@
+## テスト計画: draw-ops-batched dense-ascii 最適化
+
+### TC-01: dense ASCII 80x24 が行単位の 1 テキストランとして維持される
+- **前提**: 80x24 の Grid を同色 ASCII で全埋めする。
+- **操作**: `count_draw_ops_batched` を実行する。
+- **期待結果**: 各行が 1 ランとして集約され、`DrawOpStats` は行数ぶんの背景描画とテキスト描画のみになる。
+
+### TC-02: dirty 1 行の idle prompt で既存の高速ケースの集計が変わらない
+- **前提**: 80x24 の Grid の先頭行だけに prompt を書き、`dirty_rows = {0}` を指定する。
+- **操作**: `count_draw_ops_batched` を実行する。
+- **期待結果**: 既存の `idle_prompt/80x24-dirty1` 相当の集計結果を維持する。
+
+### TC-03: Box 文字・非 ASCII の個別描画パスが維持される
+- **前提**: Box 文字、BMP 非 ASCII、サロゲートペア、ASCII を含む Grid を用意する。
+- **操作**: `count_draw_ops_batched` を `dirty_rows` 付きで実行する。
+- **期待結果**: ASCII 以外の特殊ケースは個別描画として集計され、ASCII ラン最適化に巻き込まれない。
+
+### TC-04: dense_ascii ベンチで 80x24 の batched 回帰が解消される
+- **前提**: `cargo bench -p yatamux-renderer -- dense_ascii` を実行できる環境。
+- **操作**: `dense_ascii/80x24` の `baseline` と `batched` を比較する。
+- **期待結果**: `batched` が `baseline` より遅い状態を解消し、少なくとも回帰前より改善している。
+
+### TC-05: 暗黙デフォルト色と明示デフォルト色が同一テキストランとして集約される
+- **前提**: `CellStyle::default()` と `fg/bg` に明示的なデフォルト色を入れたスタイルを交互に並べた ASCII Grid を用意する。
+- **操作**: `count_draw_ops_batched` を実行する。
+- **期待結果**: `None` と `Some(DEFAULT_*)` が同じ実効色として扱われ、1 行 1 テキストランの `DrawOpStats` を維持する。


### PR DESCRIPTION
## Summary
- `count_draw_ops_batched()` を行単位 scanner ベースに置き換えて、Blank/ASCII の hot path を軽くしました
- `render_ops` ベンチに `baseline` / `batched` 比較と dirty-row ケースを追加しました
- `master` 比較のグラフを [docs/bench-draw-ops-vs-master.md](docs/bench-draw-ops-vs-master.md) に追加しました

## Benchmarks

# draw_ops ベンチ比較レポート

`count_draw_ops_batched()` の最適化結果を、`master` のベンチ結果と比較してまとめたレポート。

## 比較方法

- `master` の clean worktree で `cargo bench -p yatamux-renderer --bench render_ops` を実行
- 同じ worktree に今回の差分を適用して、再度 `cargo bench -p yatamux-renderer --bench render_ops` を実行
- 下記の数値は Criterion の中央値（median）を採用
- dirty-row ケースは今回の PR で追加した新規ベンチなので、PR 内の `baseline` / `batched` 比較のみ記載

## master vs batched

```mermaid
xychart-beta
    title "draw_ops benchmark vs master (median time in microseconds)"
    x-axis ["idle 80x24", "idle 200x50", "dense 80x24", "dense 200x50", "multi 80x24", "multi 200x50", "vim 80x24", "vim 200x50"]
    y-axis "us" 0 --> 70
    bar "master" [4.9587, 25.755, 11.357, 61.028, 12.642, 62.626, 11.107, 43.602]
    bar "batched" [2.1842, 18.873, 7.4662, 23.292, 9.7731, 52.708, 4.2781, 23.231]
```

| Scenario | master median (us) | PR batched median (us) | Improvement |
| --- | ---: | ---: | ---: |
| idle_prompt 80x24 | 4.9587 | 2.1842 | 56.0% faster |
| idle_prompt 200x50 | 25.755 | 18.873 | 26.7% faster |
| dense_ascii 80x24 | 11.357 | 7.4662 | 34.3% faster |
| dense_ascii 200x50 | 61.028 | 23.292 | 61.8% faster |
| multicolor 80x24 | 12.642 | 9.7731 | 22.7% faster |
| multicolor 200x50 | 62.626 | 52.708 | 15.8% faster |
| vim_style 80x24 | 11.107 | 4.2781 | 61.5% faster |
| vim_style 200x50 | 43.602 | 23.231 | 46.7% faster |

## New dirty-row cases in this PR

```mermaid
xychart-beta
    title "dirty-row benchmark added in this PR (median time in microseconds)"
    x-axis ["idle 80x24 dirty1", "idle 200x50 dirty1"]
    y-axis "us" 0 --> 1.4
    bar "baseline" [0.29046, 1.2513]
    bar "batched" [0.095574, 0.39018]
```

| Scenario | PR baseline median (us) | PR batched median (us) | Improvement |
| --- | ---: | ---: | ---: |
| idle_prompt 80x24-dirty1 | 0.29046 | 0.095574 | 67.1% faster |
| idle_prompt 200x50-dirty1 | 1.2513 | 0.39018 | 68.8% faster |

## Validation
- `cargo fmt --check`
- `cargo clippy -p yatamux-renderer --all-targets -- -D warnings`
- `cargo test -p yatamux-renderer draw_ops -- --nocapture`
- `cargo bench -p yatamux-renderer --bench render_ops`
